### PR TITLE
Optimize head tag order

### DIFF
--- a/views/layouts/default.html
+++ b/views/layouts/default.html
@@ -1,20 +1,13 @@
 <!DOCTYPE html>
 <html lang="en-US">
-
   <head>
-    {% comment %}<!-- meta charset gets set automatically by CleanSlate -->{% endcomment %}
+    {% comment %}<!-- meta charset/http-equiv gets set automatically by CleanSlate -->{% endcomment %}
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     {% if page.is_home_page? %}
       <title>{{ site.name }} at West Virginia University</title>
-      <link rel="canonical" href="{{ site.url }}">
     {% else %}
       <title>{{ page.alternate_name | default: page.name }} | {{ site.name }} | West Virginia University</title>
-      <link rel="canonical" href="{{ page.url }}" >
     {% endif %}
-    <meta name="description" content="{{ page.meta_description }}" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="google-site-verification" content="{{ site.data.google_site_verification }}" />
-
-    {% render "utilities/social_meta_tags" %}
 
     {% link_stylesheet name: "styles" %}
 
@@ -28,8 +21,15 @@
       <script data-search-pseudo-elements defer src="https://kit.fontawesome.com/a140e17a00.js" crossorigin="anonymous"></script>
     {% endif %}
 
+    {% if page.is_home_page? %}
+      <link rel="canonical" href="{{ site.url }}">
+    {% else %}
+      <link rel="canonical" href="{{ page.url }}" >
+    {% endif %}
+    <meta name="description" content="{{ page.meta_description }}" />
+    <meta name="google-site-verification" content="{{ site.data.google_site_verification }}" />
+    {% render "utilities/social_meta_tags" %}
   </head>
-
   <body class="{{ page.template_name }} page--{{ page.id }} page--{{ page.slug }} {% if edit_mode %}page--edit-mode page--hide-instructions-{{ site.data.hide_instructions }}{% endif %}">
 
     <header aria-label="masthead">


### PR DESCRIPTION
Background in video format: https://youtu.be/MHyAOZ45vnU?t=962

Here's the key slide from the talk illustrating the proper head tag order:

![Optimal head tag order for performance](https://user-images.githubusercontent.com/575865/190802755-01bf1935-07c4-42dd-8ae9-0cee1f8515e4.jpg)

I have re-ordered the tags in `default.html` to follow this recommendation.

I should note that the link to `<script src="https://kit.fontawesome.com/ba40ea27ab.js" crossorigin="anonymous"></script>` should probably use a `defer` attribute (or `asnyc`), but I did not explore if those attributes would work here.

Also relevant, we should look into adding some `preconnect` link tags. We can do that in another PR.