### PR TITLE
Improve accessibility of colored box cards. Fixes #4.

### DIFF
--- a/views/components/wvu-page-collection-colored-boxes/_wvu-page-collection-colored-boxes--v1.html
+++ b/views/components/wvu-page-collection-colored-boxes/_wvu-page-collection-colored-boxes--v1.html
@@ -76,9 +76,11 @@
           {% endif %}
 
           <div class="d-flex flex-column {{ page.content[component.region_names.itemClasses] | default: itemClasses }}">
-            <a href="{{ link_href }}" class="d-block h-100 p-3 p-xl-4 text-decoration-none text-white {{ bgColorListItem | default: 'bg-wvu-neutral--dark-gray' }}">
+            <div class="position-relative h-100 p-3 p-xl-4 text-white {{ bgColorListItem | default: 'bg-wvu-neutral--dark-gray' }}">
               <{{ htag }} class="card-title {{ itemHeaderClasses }}" id="{{ htag_id }}">
-                {{ item.alternate_name | default: item.name }}
+                <a class="stretched-link link-white text-decoration-none" href="{{ link_href }}">
+                  {{ item.alternate_name | default: item.name }}
+                </a>
               </{{ htag }}>
               {%- if item.data.description != blank %}
                 <p class="{{ itemBodyClasses }} flex-grow-1">
@@ -88,9 +90,9 @@
                 {% render "includes/wvu-collection-warnings/wvu-collection-description-warning--v1" component: component, itemName: item.name %}
               {%- endif %}
               <div class="h1 mb-0">
-                <span class="fa-solid fa-arrow-circle-right"></span>
+                <span aria-hidden="true" class="fa-solid fa-arrow-circle-right"></span>
               </div>
-            </a>
+            </div>
           </div>
 
           {% assign i = i | plus: 1 %}


### PR DESCRIPTION
See #4 for a full description. These changes make AT like screen readers only read the headings in the cards instead of the heading + full description.