### PR TITLE
Add an accessible name to the site search button.

### DIFF
--- a/views/components/wvu-nav/_wvu-nav--v1.html
+++ b/views/components/wvu-nav/_wvu-nav--v1.html
@@ -98,7 +98,10 @@
                 <input id="client" name="client" type="hidden" value="default_frontend" />
                 <div class="input-group shadow-sm w-100">
                   <input id="q" class="form-control p-2" name="q" type="search" placeholder="Search" aria-label="Search">
-                  <button class="btn btn-primary px-3 px-lg-4" name="btnG" type="submit"><span class="fas fa-search h5 mb-0"><span class="visually-hidden">Search</span></span></button>
+                  <button class="btn btn-primary px-3 px-lg-4" name="btnG" type="submit">
+                    <span class="fas fa-search h5 mb-0"></span>
+                    <span class="visually-hidden">Search</span>
+                  </button>
                 </div>
                 <div class="row pt-1">
                   <fieldset class="col-12">


### PR DESCRIPTION
FontAwesome was "eating" the inner `<span>` tag before this commit; thus, there was no accessible name on this interactive element. You can see this on [Housing v2](https://housingv2.sandbox.wvu.edu/).

This change allows us to keep the accessible name for the button.