### PR TITLE
Only apply the `.stretched-link` class when not in edit mode for the colored boxes component.

### DIFF
--- a/views/components/wvu-page-collection-colored-boxes/_wvu-page-collection-colored-boxes--v1.html
+++ b/views/components/wvu-page-collection-colored-boxes/_wvu-page-collection-colored-boxes--v1.html
@@ -78,7 +78,7 @@
           <div class="d-flex flex-column {{ page.content[component.region_names.itemClasses] | default: itemClasses }}">
             <div class="position-relative h-100 p-3 p-xl-4 text-white {{ bgColorListItem | default: 'bg-wvu-neutral--dark-gray' }}">
               <{{ htag }} class="card-title {{ itemHeaderClasses }}" id="{{ htag_id }}">
-                <a class="stretched-link link-white text-decoration-none" href="{{ link_href }}">
+                <a class="{% unless edit_mode %}stretched-link{% endunless %} link-white text-decoration-none" href="{{ link_href }}">
                   {{ item.alternate_name | default: item.name }}
                 </a>
               </{{ htag }}>


### PR DESCRIPTION
Chrome users are reporting a "Refused to connect" error for colored boxes when trying to edit content in this component in Mercury. AKA, users would click anywhere in the box and Chrome would try to route you to that page. Since Mercury's edit mode happens in an `<iframe>`, weirdness ensued and produced the "Refused to connect" error.

Related to #5 and tagging @msmoirai.