### PR TITLE
Don't output two labels for the toggle search button in the main navigation.

### DIFF
--- a/views/components/wvu-nav/_wvu-nav--v1.html
+++ b/views/components/wvu-nav/_wvu-nav--v1.html
@@ -75,7 +75,10 @@
           {% endif %}
         </ul>
       {% endif %}
-      <button class="bg-transparent border-0 text-white py-2 px-2 py-lg-0 px-lg-0" type="button" data-bs-toggle="collapse" data-bs-target="#wvuNavSearchCollapse" aria-expanded="false" aria-controls="wvuNavSearchCollapse"><i title="Search Icon" class="fa-solid fa-magnifying-glass"></i><span class="visually-hidden"> Toggle Search</span></button>
+      <button class="bg-transparent border-0 text-white py-2 px-2 py-lg-0 px-lg-0" type="button" data-bs-toggle="collapse" data-bs-target="#wvuNavSearchCollapse" aria-expanded="false" aria-controls="wvuNavSearchCollapse">
+        <span aria-hidden="true" class="fa-solid fa-magnifying-glass"></span>
+        <span class="visually-hidden">Toggle Search</span>
+      </button>
     </div>
   </div> <!-- /.container -->
 </nav>


### PR DESCRIPTION
Pre these changes, screen readers would read:

"Search Icon, Toggle Search"

Now, screen readers will read:

"Toggle Search"

Less verbose FTW.

I have checked these changes in [Volutus](http://designsystemv2demo.volutus.wvu.edu/) and everything looks good. As usual, be sure to [select the appropriate branch](https://cleanslate.volutus.wvu.edu/themes?utf8=%E2%9C%93&name=University+Relations%3A+WVU+Design+System+Version+2.0&order=sync_dt&sort=desc).