### PR TITLE
Add a hook for users to add extra content to the `<head>`.

### DIFF
--- a/views/components/wvu-youtube-playlist/_wvu-youtube-playlist--v1.html
+++ b/views/components/wvu-youtube-playlist/_wvu-youtube-playlist--v1.html
@@ -20,11 +20,19 @@
 {% render "utilities/wvu-component-tag/wvu-component-tag--v1" component: component, content: component_content %}
 {% render "includes/wvu-component-footer/wvu-component-footer--v1" component: component %}
 
+{% content_for "header_extras" %}
+  <link rel="preconnect" href="https://cdn.jsdelivr.net">
+  <link rel="preconnect" href="https://www.youtube.com">
+  {% if page.data.youtube_playlist_id != blank %}
+    <link rel="stylesheet" href="https://static.wvu.edu/youtube-playlist-player/stylesheets/styles.css">
+  {% endif %}
+{% endcontent_for %}
+
 {% content_for "page_js" %}
-  <script src="https://code.jquery.com/jquery-3.6.0.slim.min.js" integrity="sha256-u7e5khyithlIdTpu22PHhENmPcRdFiHRjhAuHcs05RI=" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.slim.min.js" integrity="sha256-w8CvhFs7iHNVUtnSP0YKEg00p9Ih13rlL9zGqvLdePA=" crossorigin="anonymous"></script>
   <script src="https://www.youtube.com/iframe_api"></script>
   <script>
-    var pl_id = "{{ page.data.youtube_playlist_id }}" // Add your Playlist's ID (found in the URL) via Page Properties > Custom Data
+    const pl_id = '{{ page.data.youtube_playlist_id }}'; // Add your Playlist's ID (found in the URL) via Page Properties > Custom Data
   </script>
   <script src="https://static.wvu.edu/youtube-playlist-player/js/youtube-playlist-player.min.js"></script>
 {% endcontent_for %}

--- a/views/layouts/default.html
+++ b/views/layouts/default.html
@@ -23,9 +23,7 @@
 
     {% link_stylesheet name: "styles" %}
 
-    {% if page.data.youtube_playlist_id != blank %}
-      <link rel="stylesheet" href="https://static.wvu.edu/youtube-playlist-player/stylesheets/styles.css">
-    {% endif %}
+    {{ content_for.header_extras }}
 
     {% if edit_mode or page.data.useFACSS == '1' %}
       <script src="https://kit.fontawesome.com/ba40ea27ab.js" crossorigin="anonymous"></script>
@@ -73,7 +71,6 @@
             {% render "components/wvu-backpage-header" %}
           {% endif %}
       {% endcase %}
-
     </header>
 
     {{ __TEMPLATE_CONTENT__ }}


### PR DESCRIPTION
Just like we have the `page_js` hook for extra JS in the footer, it makes sense that we should have a hook for extra stuff in the head.

Do so by adding this to a template/partial:

```html
{% content_for "header_extras" %}
  <!-- Extra content for your site's <head> goes here -->
{% endcontent_for %}
```

With this change, the [YouTube Playlist Player](https://cleanslatecms.wvu.edu/content-creator-video-tutorials) can insert its stylesheet into the head from the component itself, versus having to keep its stylesheet in `default.html`.

Fair warning: I have not tested these changes to this component. Is there a YTPP component to test with on Volutus?