### PR TITLE
Remove `role="button"` and `role="group"` where appropriate.

### DIFF
--- a/mock_data.yml
+++ b/mock_data.yml
@@ -20,7 +20,7 @@ editable_region:
     <p class="lead pb-2">
       This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.
     </p>
-    <a class="btn btn-wvu-blue btn-lg" href="#" role="button">Call to Action</a>
+    <a class="btn btn-wvu-blue btn-lg" href="#">Call to Action</a>
     <p class="mt-2">Here is a <a href="#" class="text-wvu-accent--dark-blue">Secondary Call to Action</a></p>
   wvu-action-hero-card-1__header: "Action Hero Card Header"
   wvu-action-hero-card-1__main: |
@@ -163,7 +163,7 @@ editable_region:
   wvu-hero-1__header: "It Starts Now"
   wvu-hero-1__main: |
     <p class="lead py-2"><%= Faker::Hacker.say_something_smart %> <%= Faker::Hacker.say_something_smart %></p>
-    <a class="btn btn-primary btn-lg" href="#" role="button">Call to Action</a>
+    <a class="btn btn-primary btn-lg" href="#">Call to Action</a>
   wvu-lede-text-1__main: "<%= Faker::Lorem.paragraph(5) %>"
   wvu-log-in-1__main: |
     <form class="px-3 py-4">
@@ -289,7 +289,7 @@ editable_region:
   wvu-stat-sheet-1__header: "Estimate your scholarships."
   wvu-stat-sheet-1__main: |
     <p class="lead py-2 w-75 mx-auto">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
-    <a class="btn btn-primary btn-lg" href="#" role="button">Call to Action</a>
+    <a class="btn btn-primary btn-lg" href="#">Call to Action</a>
   wvu-stat-sheet-1__stats: |
     <h2 class="wvu-h3">Tuition Rates</h2>
     <p class="mb-2">Looking for a quick ballpark figure? We have you covered.</p>

--- a/views/components/wvu-action-hero-banner/_wvu-action-hero-banner--v1.html
+++ b/views/components/wvu-action-hero-banner/_wvu-action-hero-banner--v1.html
@@ -19,7 +19,7 @@
           </h2>
           {% editable_region_block name: component.region_names.main, scope: component.scope %}
             <p class="lead pb-2 text-white">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
-            <a class="btn btn-outline-white" href="#" role="button">Call to Action</a>
+            <a class="btn btn-outline-white" href="#">Call to Action</a>
           {% endeditable_region_block %}
         </div>
       {% endcapture %}

--- a/views/components/wvu-action-hero/_wvu-action-hero--v1.html
+++ b/views/components/wvu-action-hero/_wvu-action-hero--v1.html
@@ -20,7 +20,7 @@
         {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Main Content</span>{% endif %}
         {% editable_region_block name: component.region_names.main, scope: component.scope %}
           <p class="lead pb-2">This is a simple hero unit, a simple jumbotron-style component for calling
-          extra attention to featured content or information.</p><a class="btn btn-wvu-blue btn-lg" href="#" role="button">Call to Action</a><p class="mt-2 mb-0">Here is a <a href="#" class="text-wvu-accent--dark-blue">Secondary Call to Action</a></p>
+          extra attention to featured content or information.</p><a class="btn btn-wvu-blue btn-lg" href="#">Call to Action</a><p class="mt-2 mb-0">Here is a <a href="#" class="text-wvu-accent--dark-blue">Secondary Call to Action</a></p>
         {% endeditable_region_block %}
 
       {% endcapture %}

--- a/views/components/wvu-article-index/_wvu-article-index--v1.html
+++ b/views/components/wvu-article-index/_wvu-article-index--v1.html
@@ -83,10 +83,10 @@
 
           {% assign pagination = articles | blog_pagination %}
           {% if pagination.total_pages > 1 %}
-            <div class="btn-group" role="group" aria-label="Basic example">
-              <a type="button" href="{{ pagination.next_page_url }}" class="btn btn-secondary page-link{% if pagination.is_last_page %} disabled{% endif %}">Older Articles</a>
-              <a type="button" href="{{ pagination.prev_page_url }}" class="btn btn-secondary page-link{% if pagination.is_first_page %} disabled{% endif %}">Newer Articles</a>
-            </div>
+            <nav class="btn-group" aria-label="Pagination">
+              <a href="{{ pagination.next_page_url }}" class="btn btn-secondary page-link{% if pagination.is_last_page %} disabled{% endif %}">Older Articles</a>
+              <a href="{{ pagination.prev_page_url }}" class="btn btn-secondary page-link{% if pagination.is_first_page %} disabled{% endif %}">Newer Articles</a>
+            </nav>
           {% endif %}
         {% else %}
           <p>No blog posts found. Try again later, perhaps?</p>

--- a/views/components/wvu-backpage-header/_wvu-backpage-header--v1.html
+++ b/views/components/wvu-backpage-header/_wvu-backpage-header--v1.html
@@ -67,9 +67,9 @@
             <div class="wvu-z-index-max">
               <h2 id="header-select-menu-label" class="text-uppercase text-white h6">In This Section:</h2>
               <div class="dropdown">
-                <a href="#" class="btn btn-white btn-lg bs-dropdown-toggle w-100 text-start d-flex align-items-center justify-content-between" role="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
-                  Select Page <i class="fa-solid fa-angle-down float-right"></i>
-                </a>
+                <button class="btn btn-white btn-lg bs-dropdown-toggle w-100 text-start d-flex align-items-center justify-content-between" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
+                  Select Page <span aria-hidden="true" class="fa-solid fa-angle-down float-right"></span>
+                </button>
                 <ul class="dropdown-menu w-100" aria-labelledby="dropdownMenuButton1">
                   {% for page in page.children %}
                     <li><a class="dropdown-item" href="{{ page.url }}">{{ page.alternate_name | default: page.name }}</a></li>

--- a/views/components/wvu-directory/_wvu-directory--v1.html
+++ b/views/components/wvu-directory/_wvu-directory--v1.html
@@ -75,10 +75,10 @@
     {% comment %}
     {% assign pagination = items | blog_pagination %}
     {% if pagination.total_pages > 1 %}
-      <div class="btn-group" role="group" aria-label="Basic example">
-        <a type="button" href="{{ pagination.next_page_url }}" class="btn btn-secondary page-link{% if pagination.is_last_page %} disabled{% endif %}">Older Articles</a>
-        <a type="button" href="{{ pagination.prev_page_url }}" class="btn btn-secondary page-link{% if pagination.is_first_page %} disabled{% endif %}">Newer Articles</a>
-      </div>
+      <nav class="btn-group" aria-label="Pagination">
+        <a href="{{ pagination.next_page_url }}" class="btn btn-secondary page-link{% if pagination.is_last_page %} disabled{% endif %}">Older Articles</a>
+        <a href="{{ pagination.prev_page_url }}" class="btn btn-secondary page-link{% if pagination.is_first_page %} disabled{% endif %}">Newer Articles</a>
+      </nav>
     {% endif %}
     {% endcomment %}
 

--- a/views/components/wvu-hero-w-subnav/_wvu-hero-w-subnav--v1.html
+++ b/views/components/wvu-hero-w-subnav/_wvu-hero-w-subnav--v1.html
@@ -22,7 +22,7 @@
         {% comment %}<!-- Editable region for main content. -->{% endcomment %}
         {% editable_region_block name: component.region_names.main scope: component.scope %}
           <p class="lead py-2">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
-          <a class="btn btn-primary btn-lg" href="#" role="button">Call to Action</a>
+          <a class="btn btn-primary btn-lg" href="#">Call to Action</a>
         {% endeditable_region_block %}
       </div>
       <div class="col-md-6 col-xl-5 ms-xl-auto">

--- a/views/components/wvu-hero-w-video/_wvu-hero-w-video--v1.html
+++ b/views/components/wvu-hero-w-video/_wvu-hero-w-video--v1.html
@@ -28,7 +28,7 @@
           {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Main Content</span>{% endif %}
           {% editable_region_block name: component.region_names.main scope: component.scope %}
             <p class="lead py-2">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
-            <a class="btn btn-primary" href="#" role="button">Call to Action</a>
+            <a class="btn btn-primary" href="#">Call to Action</a>
           {% endeditable_region_block %}
         </div>
       </div>

--- a/views/components/wvu-hero/_wvu-hero--v1.html
+++ b/views/components/wvu-hero/_wvu-hero--v1.html
@@ -30,7 +30,7 @@
             {% comment %}<!-- Editable region for main content. -->{% endcomment %}
             {% editable_region_block name: component.region_names.main scope: component.scope %}
               <p class="lead py-2">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
-              <a class="btn btn-primary btn-lg" href="#" role="button">Call to Action</a>
+              <a class="btn btn-primary btn-lg" href="#">Call to Action</a>
             {% endeditable_region_block %}
           </div>
         </div>

--- a/views/components/wvu-profile-hero-w-border/_wvu-profile-hero-w-border--v1.html
+++ b/views/components/wvu-profile-hero-w-border/_wvu-profile-hero-w-border--v1.html
@@ -34,7 +34,7 @@
               path so highlights. Pushback race without a finish line. My capacity
               is full in an ideal world.
             </p>
-            <a class="btn btn-primary btn-sm" href="#" role="button">Call to Action</a>
+            <a class="btn btn-primary btn-sm" href="#">Call to Action</a>
           {% endeditable_region_block %}
         </div>
       </div>

--- a/views/components/wvu-profile-hero/_wvu-profile-hero--v1.html
+++ b/views/components/wvu-profile-hero/_wvu-profile-hero--v1.html
@@ -29,7 +29,7 @@
             {% editable_region_block name: component.region_names.main scope: component.scope %}
               <p class="h1 pt-2 iowan-old-style-italic">Jane Schmoe, Biology, Class of ’22</p>
               <p class="lead py-2">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
-              <a class="btn btn-primary btn-lg" href="#" role="button">Call to Action</a>
+              <a class="btn btn-primary btn-lg" href="#">Call to Action</a>
             {% endeditable_region_block %}
           </div>
         </div>

--- a/views/components/wvu-stat-sheet/_wvu-stat-sheet--v1.html
+++ b/views/components/wvu-stat-sheet/_wvu-stat-sheet--v1.html
@@ -25,7 +25,7 @@
         {% endif %}
         {% editable_region_block name: component.region_names.main, scope: component.scope %}
           <p class="lead py-2 w-75 mx-auto">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
-          <a class="btn btn-primary btn-lg" href="#" role="button">Call to Action</a>
+          <a class="btn btn-primary btn-lg" href="#">Call to Action</a>
         {% endeditable_region_block %}
       </div>
       <div class="col-md-4 {{ page.content[statCardClassesEditableRegionName] | default: defaultStatCardClasses }}">

--- a/views/includes/wvu-component-footer/_wvu-component-footer--v1.html
+++ b/views/includes/wvu-component-footer/_wvu-component-footer--v1.html
@@ -12,7 +12,7 @@
   {% assign ariaLabelRegionName = component.name | append: '-aria-label' %}
   {% assign customItemColorsRegion = component.name | append: '__item-colors' %}
 
-  <button class="editpanelbutton wvu-z-index-max text-white p-1 rounded-sm d-inline-block btn btn-sm btn-wvu-neutral--black wvu-grow-shadow wvu-z-index-content position-absolute {% if component.baseName == "breadcrumbs" %}mt-4 {% else %}mt-n4 {% endif %}ml-1 ms-1" data-bs-toggle="collapse" data-bs-target="#editpanel-{{ component.name }}" role="button" aria-expanded="false" aria-controls="editpanel-{{ component.name }}"><small class="d-block"><i class="far fa-edit"></i> Edit <span class="text-capitalize">{{ component.baseName | replace: '-', ' ' }}</span> {{ component.number }} Styles</small></button>
+  <button class="editpanelbutton wvu-z-index-max text-white p-1 rounded-sm d-inline-block btn btn-sm btn-wvu-neutral--black wvu-grow-shadow wvu-z-index-content position-absolute {% if component.baseName == "breadcrumbs" %}mt-4 {% else %}mt-n4 {% endif %}ml-1 ms-1" data-bs-toggle="collapse" data-bs-target="#editpanel-{{ component.name }}" type="button" aria-expanded="false" aria-controls="editpanel-{{ component.name }}"><small class="d-block"><i class="far fa-edit"></i> Edit <span class="text-capitalize">{{ component.baseName | replace: '-', ' ' }}</span> {{ component.number }} Styles</small></button>
   <section class="editpanel px-2 px-md-5 pt-2 pb-3 mb-0 text-light bg-wvu-neutral--black position-relative collapse multi-collapse" id="editpanel-{{ component.name }}">
     <p class="mb-0">
       <!-- Region Name: {{component.region_names.classes}} -->


### PR DESCRIPTION
I believe `role="button"` is a copy-paste hold over from the Bootstrap docs. It's unnecessary in these cases. Explicitly setting roles changes native HTML semantics (in this case, an `<a>` would be "transformed" to a `<button>` by AT).

The pagination components are better served using `<nav>` elements with `aria-label` attributes.

If there's a `<button>` element, chances are you should also add `type="button"` if it's not already present.