### PR TITLE
If a user closes the Alert Banner component, keep it closed until they open a new tab/window.

### DIFF
--- a/javascripts/bootstrap-alert--custom.js
+++ b/javascripts/bootstrap-alert--custom.js
@@ -11,7 +11,6 @@ const hideBootstrapAlert = (() => {
   /* global sessionStorage bootstrap */
 
   // Variables:
-  let hideAlert = 'false'; // NOTE: Can't store booleans in sessionStorage
   const alertNode = document.querySelector('#js-bootstrap-alert');
   const focusedElement = document.querySelector('#js-masthead');
 
@@ -23,18 +22,17 @@ const hideBootstrapAlert = (() => {
   const alert = bootstrap.Alert.getOrCreateInstance(alertNode);
 
   // If someone has already clicked to hide the alert, hide it:
-  const alertState = sessionStorage.getItem('hideAlertKey');
-  if (alertState === 'true') {
+  const hideAlert = sessionStorage.getItem('hideAlertKey');
+  if (hideAlert === 'true') { // NOTE: Can't store booleans in sessionStorage
     return alert.close();
   }
 
   // Add `fade show` classes to animate the component on close when the alert is showing:
   alertNode.classList.add('fade', 'show');
 
-  // Now that we know it's showing, set session storage state and close it on click:
+  // Now that we know it's showing, set session storage state upon click/close & move focus:
   alertNode.addEventListener('closed.bs.alert', () => {
-    hideAlert = 'true';
-    sessionStorage.setItem('hideAlertKey', hideAlert); // Store alert state
+    sessionStorage.setItem('hideAlertKey', 'true'); // Set alert state
     focusedElement.setAttribute('tabindex', '-1'); // Required for non-interactive elements
     focusedElement.focus();
   }, {

--- a/javascripts/bootstrap-alert--custom.js
+++ b/javascripts/bootstrap-alert--custom.js
@@ -1,0 +1,44 @@
+/**
+  Keep alert banner closed on page refresh
+  --------------------------------
+  This JS targets the Alert Banner component and uses Session Storage
+  to keep the alert closed after a user has hit the close button.
+  https://dsws.sandbox.wvu.edu/components/essential-elements/alert-banner
+*/
+
+const hideBootstrapAlert = (() => {
+  'use strict';
+  /* global sessionStorage bootstrap */
+
+  // Variables:
+  let hideAlert = 'false'; // NOTE: Can't store booleans in sessionStorage
+  const alertNode = document.querySelector('#js-bootstrap-alert');
+  const focusedElement = document.querySelector('#js-masthead');
+
+  // Variable checks:
+  if (!alertNode) return;
+  if (!focusedElement) return;
+
+  // Initialize alert to be used with the Bootstrap JS API:
+  const alert = bootstrap.Alert.getOrCreateInstance(alertNode);
+
+  // If someone has already clicked to hide the alert, hide it:
+  const alertState = sessionStorage.getItem('hideAlertKey');
+  if (alertState === 'true') {
+    return alert.close();
+  }
+
+  // Add `fade show` classes to animate the component on close when the alert is showing:
+  alertNode.classList.add('fade', 'show');
+
+  // Now that we know it's showing, set session storage state and close it on click:
+  alertNode.addEventListener('closed.bs.alert', () => {
+    hideAlert = 'true';
+    sessionStorage.setItem('hideAlertKey', hideAlert); // Store alert state
+    focusedElement.setAttribute('tabindex', '-1'); // Required for non-interactive elements
+    focusedElement.focus(); // NOTE: This must come before `alert.close();`
+    alert.close();
+  }, {
+    once: true
+  });
+})();

--- a/javascripts/bootstrap-alert--custom.js
+++ b/javascripts/bootstrap-alert--custom.js
@@ -36,8 +36,7 @@ const hideBootstrapAlert = (() => {
     hideAlert = 'true';
     sessionStorage.setItem('hideAlertKey', hideAlert); // Store alert state
     focusedElement.setAttribute('tabindex', '-1'); // Required for non-interactive elements
-    focusedElement.focus(); // NOTE: This must come before `alert.close();`
-    alert.close();
+    focusedElement.focus();
   }, {
     once: true
   });

--- a/views/components/wvu-alert-banner/_wvu-alert-banner--v1.html
+++ b/views/components/wvu-alert-banner/_wvu-alert-banner--v1.html
@@ -1,4 +1,4 @@
-<section class="wvu-alert-banner py-2 mb-0 {{ site.data.alert_banner_classes | default: 'alert alert-info' }}" aria-label="Alert">
+<section id="js-bootstrap-alert" role="alert" aria-label="Alert" class="wvu-alert-banner py-2 mb-0 {{ site.data.alert_banner_classes | default: 'alert alert-info' }}">
   <div class="container py-2">
     <div class="d-flex justify-content-between">
       <div>
@@ -6,17 +6,11 @@
         <p class="mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
       {% endeditable_region_block %}
       </div>
-      <button type="button" class="btn-close ms-2" aria-label="Close Alert Banner"></button>
+      <button type="button" class="btn-close ms-2" data-bs-dismiss="alert" aria-label="Close Alert Banner"></button>
     </div>
   </div>
 </section>
 
 {% content_for "page_js" %}
-  <script>
-    var alertBanner = document.querySelector('.wvu-alert-banner')
-    var closeButton = document.querySelector('.wvu-alert-banner button')
-    closeButton.addEventListener('click', event => {
-      alertBanner.classList.add('d-none')
-    })
-  </script>
+  {% link_javascript name: "bootstrap-alert--custom" %}
 {% endcontent_for %}

--- a/views/components/wvu-masthead/_wvu-masthead--v1.html
+++ b/views/components/wvu-masthead/_wvu-masthead--v1.html
@@ -1,5 +1,5 @@
 <!-- Markup -->
-<div class="wvu-masthead bg-wvu-blue">
+<div id="js-masthead" class="wvu-masthead bg-wvu-blue">
   <div class="container">
     <div class="row">
       <div class="align-self-center col">


### PR DESCRIPTION
Works [in Staging](https://designsystemv2demo.volutus.wvu.edu/home-alt) (be sure you're on the correct branch). Re-open a browser tab if you want to see it again after closing or [clear your session storage](https://developer.chrome.com/docs/devtools/storage/sessionstorage/).

Closes #21. 