### PR TITLE
Fix Siteimprove "Text in all caps" accessibility best practices warning.

### DIFF
--- a/mock_data.yml
+++ b/mock_data.yml
@@ -194,8 +194,8 @@ editable_region:
   wvu-profile-teaser-1__image: |
     <img class="rounded-circle shadow" src="https://via.placeholder.com/960x960" alt="Placeholder" />
   wvu-profile-teaser-1__main: |
-    <p class="text-uppercase">
-      Label goes here
+    <p>
+      <span class="text-uppercase">Label goes here</span>
     </p>
     <h2 class="wvu-shout h1">Firstname Lastname</h2>
     <p class="h3 iowan-old-style-italic mb-2">

--- a/scss/utilities/_wvu-type.scss
+++ b/scss/utilities/_wvu-type.scss
@@ -125,8 +125,10 @@
 }
 
 // Usage example:
-// <p class="text-uppercase iowan-old-style wvu-text-letter-spacing">
-//   ...
+// <p class="iowan-old-style wvu-text-letter-spacing">
+//   <span class="text-uppercase">
+//     ...
+//   </span>
 // </p>
 
 // Typography Pallette

--- a/views/components/custom/_wvu-component-doc__shared-partial.html
+++ b/views/components/custom/_wvu-component-doc__shared-partial.html
@@ -3,12 +3,14 @@
     <div class="row">
       <div class="col-md-8 me-md-auto">
         <h2 class="h1 wvu-bar wvu-bar--bottom">Shared CleanSlate Partial</h2>
-        <p class="text-uppercase">
-          {% if page.data.isDynamic == '1' %}
-            <strong>Type:</strong> <span class="helvetica-neue-light">Dynamic (pulls data from other pages in site)</span>
-          {% else %}
-            <strong>Type:</strong> <span class="helvetica-neue-light">Static (uses editable regions)</span)
-          {% endif %}
+        <p>
+          <span class="text-uppercase">
+            {% if page.data.isDynamic == '1' %}
+              <strong>Type:</strong> <span class="helvetica-neue-light">Dynamic (pulls data from other pages in site)</span>
+            {% else %}
+              <strong>Type:</strong> <span class="helvetica-neue-light">Static (uses editable regions)</span>
+            {% endif %}
+          </span>
         </p>
 
         <p>This component corresponds to the latest version of the shared <code>{{ page.slug }}</code> partial in CleanSlate.

--- a/views/components/wvu-article/_wvu-article--v1.html
+++ b/views/components/wvu-article/_wvu-article--v1.html
@@ -39,15 +39,15 @@
                 <img alt="Mountaineer Statue" src="https://static.volutus.wvu.edu/global/images/mountaineer-statue-960x640.jpg">
               </figure>
               <figcaption class="mb-4">
-              <p class="small d-block iowan-old-style">
-                At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga.
-              </p>
+                <p class="small d-block iowan-old-style">
+                  At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga.
+                </p>
               </figcaption>
               <p>
-              At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio.
+                At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio.
               </p>
               <blockquote class="iowan-old-style-black-italic h2 wvu-bar wvu-bar--center my-4 pb-1 text-center mx-lg-n5">Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus.
-              <span class="d-block iowan-old-style text-uppercase wvu-letter-spacing h5 mt-2">Joe Schmoe</span>
+                <span class="d-block iowan-old-style text-uppercase wvu-letter-spacing h5 mt-2">Joe Schmoe</span>
               </blockquote>
               <p>Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.</p>
             {% endeditable_region_block %}

--- a/views/components/wvu-backpage-header/_wvu-backpage-header--v1.html
+++ b/views/components/wvu-backpage-header/_wvu-backpage-header--v1.html
@@ -32,12 +32,14 @@
     <div class="row align-items-stretch">
       <div class="col-8 mt-5">
         {% if page.data.header_label == '1' %}
-          <p class="text-uppercase helvetica-neue-light mb-1">
-            {% comment %}<!-- This is just a label for the editable region that follows in order to make it clear to content editors what the region is for (in case they delete content and forget). -->{% endcomment %}
-            {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Label</span>{% endif %}
-            {% editable_region_block name: componentHeaderLabel %}
-              <span class="wvu-shout text-wvu-gold text-uppercase">Label pre</span> <span class="text-uppercase">Label Post</span>
-            {% endeditable_region_block %}
+          <p class="helvetica-neue-light mb-1">
+            <span class="text-uppercase">
+              {% comment %}<!-- This is just a label for the editable region that follows in order to make it clear to content editors what the region is for (in case they delete content and forget). -->{% endcomment %}
+              {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Label</span>{% endif %}
+              {% editable_region_block name: componentHeaderLabel %}
+                <span class="wvu-shout text-wvu-gold text-uppercase">Label pre</span> <span class="text-uppercase">Label Post</span>
+              {% endeditable_region_block %}
+            </span>
           </p>
         {% endif %}
         {% comment %}<!-- This is where you can add utility classes that will apply to the heading. -->{% endcomment %}

--- a/views/components/wvu-profile-teaser/_wvu-profile-teaser--v1.html
+++ b/views/components/wvu-profile-teaser/_wvu-profile-teaser--v1.html
@@ -64,8 +64,10 @@
         </div>
         <div class="col-md-9 col-lg-6">
           {% if item.content['wvu-profile-1__header-label'] != blank %}
-            <p class="text-uppercase">
-              {{ item.content['wvu-profile-1__header-label'] }}
+            <p>
+              <span class="text-uppercase">
+                {{ item.content['wvu-profile-1__header-label'] }}
+              </span>
             </p>
           {% endif %}
 

--- a/views/components/wvu-profile-teaser/_wvu-profile-teaser-e--v1.html
+++ b/views/components/wvu-profile-teaser/_wvu-profile-teaser-e--v1.html
@@ -16,8 +16,10 @@
         <div class="row">
           <div class="col-lg-8 mb-3 mb-lg-0">
             {% editable_region_block name: component.region_names.main, scope: component.scope %}
-              <p class="text-uppercase">
-                Label goes here
+              <p>
+                <span class="text-uppercase">
+                  Label goes here
+                </span>
               </p>
               <h2 class="wvu-shout h1" id="{{ component.name }}-label">Headline Goes Here</h2>
               <p class="h3 iowan-old-style-italic mb-2">

--- a/views/components/wvu-timeline/_wvu-timeline--v1.html
+++ b/views/components/wvu-timeline/_wvu-timeline--v1.html
@@ -41,7 +41,11 @@
             <li>
               <div class="{{ itemClasses }}">
                 {% editable_region_block name: componentPanelDate, scope: component.scope %}
-                  <p class="iowan-old-style-black small text-uppercase wvu-text-letter-spacing text-wvu-accent--burnt-orange">March 29, 1987</p>
+                  <p class="iowan-old-style-black small wvu-text-letter-spacing text-wvu-accent--burnt-orange">
+                    <span class="text-uppercase">
+                      March 29, 1987
+                    </span>
+                  </p>
                 {% endeditable_region_block %}
                 <div class="mt-2">
                   {% editable_region_block name: componentPanelMain, scope: component.scope %}

--- a/views/includes/wvu-profile-info/_wvu-profile-info--v1.html
+++ b/views/includes/wvu-profile-info/_wvu-profile-info--v1.html
@@ -1,31 +1,39 @@
 {% if profileItem.template_name == 'student' %}
   {% if profileItem.content['wvu-profile-1__major'] != blank %}
-    <p class="text-uppercase small helvetica-neue-light mb-0 text-white">
-      {% if profileItem.content['wvu-profile-1__major'] != blank %}
-        {{ profileItem.content['wvu-profile-1__major'] }}
-      {% endif %}
+    <p class="small helvetica-neue-light mb-0 text-white">
+      <span class="text-uppercase">
+        {% if profileItem.content['wvu-profile-1__major'] != blank %}
+          {{ profileItem.content['wvu-profile-1__major'] }}
+        {% endif %}
+      </span>
     </p>
   {% endif %}
   {% if profileItem.content['wvu-profile-1__graduation-year'] != blank %}
-    <p class="text-uppercase small helvetica-neue-light mb-0 text-white">
-      {% if profileItem.content['wvu-profile-1__graduation-year'] != blank %}
-        {{ profileItem.content['wvu-profile-1__graduation-year'] }}
-      {% endif %}
+    <p class="small helvetica-neue-light mb-0 text-white">
+      <span class="text-uppercase">
+        {% if profileItem.content['wvu-profile-1__graduation-year'] != blank %}
+          {{ profileItem.content['wvu-profile-1__graduation-year'] }}
+        {% endif %}
+      </span>
     </p>
   {% endif %}
 {% else %}
   {% if profileItem.content['wvu-profile-1__title'] != blank %}
-    <p class="text-uppercase small helvetica-neue-light mb-0 text-white">
-      {% if profileItem.content['wvu-profile-1__title'] != blank %}
-        {{ profileItem.content['wvu-profile-1__title'] }}
-      {% endif %}
+    <p class="small helvetica-neue-light mb-0 text-white">
+      <span class="text-uppercase">
+        {% if profileItem.content['wvu-profile-1__title'] != blank %}
+          {{ profileItem.content['wvu-profile-1__title'] }}
+        {% endif %}
+      </span>
     </p>
   {% endif %}
   {% if profileItem.content['wvu-profile-1__organization'] != blank %}
-    <p class="text-uppercase small helvetica-neue-light mb-0 text-white">
-      {% if profileItem.content['wvu-profile-1__organization'] != blank %}
-        {{ profileItem.content['wvu-profile-1__organization'] }}
-      {% endif %}
+    <p class="small helvetica-neue-light mb-0 text-white">
+      <span class="text-uppercase">
+        {% if profileItem.content['wvu-profile-1__organization'] != blank %}
+          {{ profileItem.content['wvu-profile-1__organization'] }}
+        {% endif %}
+      </span>
     </p>
   {% endif %}
 {% endif %}


### PR DESCRIPTION
This happens when you apply `text-uppercase` to `<p>` tags. Siteimprove is unable to determine the length of the paragraph tag; thus, it thinks there's a huge paragraph of text in all caps. This is almost never the case; however, these changes should circumvent this warning.

You can see this warning by going to the [Timeline component](https://dsws.sandbox.wvu.edu/components/data-presentations/timeline) on the docs site and running a check with the accessibility browser extension.