### PR TITLE
Change all `<i>` tags to `<span>` tags and add `aria-hidden`.

### DIFF
--- a/views/components/wvu-article-archive/_wvu-article-archive--v1.html
+++ b/views/components/wvu-article-archive/_wvu-article-archive--v1.html
@@ -5,4 +5,4 @@
   {%- endfor -%}
 </ul>
 {%- endif %}
-<p><i class="fa-solid fa-rss-square text-wvu-accent--burnt-orange text-decoration-none"></i> <a href="{{ page.url | append: '.rss' }}"> <span class="text-primary">Articles RSS Feed</span></a></p>
+<p><span class="fa-solid fa-rss-square text-wvu-accent--burnt-orange text-decoration-none" aria-hidden="true"></span> <a href="{{ page.url | append: '.rss' }}"> <span class="text-primary">Articles RSS Feed</span></a></p>

--- a/views/components/wvu-big-search/_wvu-big-search--v1.html
+++ b/views/components/wvu-big-search/_wvu-big-search--v1.html
@@ -26,7 +26,12 @@
               <input id="client" name="client" type="hidden" value="default_frontend" />
               <div class="input-group shadow-sm w-100">
                 <input id="q" class="form-control p-2 h1 mb-0" name="q" type="search" placeholder="Type in your search term." aria-label="Big Site Search">
-                <button class="btn btn-primary px-3 px-lg-4" name="btnG" type="submit"><span class="h5 mb-0 d-block"><i class="fa-solid fa-magnifying-glass"></i></span><span class="visually-hidden">Search</span></span></button>
+                <button class="btn btn-primary px-3 px-lg-4" name="btnG" type="submit">
+                  <span class="h5 mb-0 d-block">
+                    <span class="fa-solid fa-magnifying-glass" aria-hidden="true"></span>
+                  </span>
+                  <span class="visually-hidden">Search</span></span>
+                </button>
               </div>
             </form>
           </div>

--- a/views/components/wvu-blob-a/_wvu-blob-a--v1.html
+++ b/views/components/wvu-blob-a/_wvu-blob-a--v1.html
@@ -40,7 +40,7 @@
             <div class="rounded-circle h2 bg-wvu-accent--blue text-white d-inline-block align-middle mt-n5 p-3">
               <div class="position-absolute ms-n2 mt-n2">
                 {% editable_region_block name: iconRegionName, scope: component.scope %}
-                  <i class="fa-solid fa-heart"></i>
+                  <span class="fa-solid fa-heart" aria-hidden="true"></span>
                 {% endeditable_region_block %}
               </div>
             </div>

--- a/views/components/wvu-contact-info/_wvu-contact-info--v1.html
+++ b/views/components/wvu-contact-info/_wvu-contact-info--v1.html
@@ -22,7 +22,7 @@
         {% endeditable_region_block %}
         {% if edit_mode or page.content[addressEditableRegionName] != blank %}
           <div class="d-flex mb-2 mt-4">
-            <div class="h3"><i class="fa-solid fa-location-pin"></i></div>
+            <div class="h3"><span class="fa-solid fa-location-pin" aria-hidden="true"></span></div>
             <div class="ms-2">
               {% comment %}<!-- This is just a label for the editable region that follows in order to make it clear to content editors what the region is for (in case they delete content and forget). -->{% endcomment %}
               {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Address</span>{% endif %}
@@ -41,7 +41,7 @@
         {% endif %}
         {% if edit_mode or page.content[phoneEditableRegionName] != blank %}
           <div class="d-flex mb-2">
-            <div class="h3"><i class="fa-solid fa-phone"></i></div>
+            <div class="h3"><span class="fa-solid fa-phone" aria-hidden="true"></span></div>
             <div class="ms-2">
               {% comment %}<!-- This is just a label for the editable region that follows in order to make it clear to content editors what the region is for (in case they delete content and forget). -->{% endcomment %}
               {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Phone</span>{% endif %}
@@ -59,7 +59,7 @@
         {% endif %}
         {% if edit_mode or page.content[emailEditableRegionName] != blank %}
           <div class="d-flex mb-2">
-            <div class="h3"><i class="fa-solid fa-envelope"></i></div>
+            <div class="h3"><span class="fa-solid fa-envelope" aria-hidden="true"></span></div>
             <div class="ms-2">
               {% comment %}<!-- This is just a label for the editable region that follows in order to make it clear to content editors what the region is for (in case they delete content and forget). -->{% endcomment %}
               {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Phone</span>{% endif %}
@@ -77,7 +77,7 @@
         {% endif %}
         {% if edit_mode or page.content[individualEditableRegionName] != blank %}
           <div class="d-flex mb-2">
-            <div class="h3"><i class="fa-solid fa-user-group"></i></div>
+            <div class="h3"><span class="fa-solid fa-user-group" aria-hidden="true"></span></div>
             <div class="ms-2">
               {% comment %}<!-- This is just a label for the editable region that follows in order to make it clear to content editors what the region is for (in case they delete content and forget). -->{% endcomment %}
               {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Phone</span>{% endif %}
@@ -88,7 +88,7 @@
                 <p>
                   Looking for someone specific?
                 </p>
-                <p><a class="btn btn-outline-dark" href="#"><i class="fa-solid fa-circle-arrow-right"></i> Meet the Team</a></p>
+                <p><a class="btn btn-outline-dark" href="#"><span class="fa-solid fa-circle-arrow-right" aria-hidden="true"></span> Meet the Team</a></p>
               {% endeditable_region_block %}
             </div>
           </div>

--- a/views/components/wvu-footer/_wvu-footer--v1.html
+++ b/views/components/wvu-footer/_wvu-footer--v1.html
@@ -53,9 +53,24 @@
           <li class="list-inline-item"><a class="{{ link_class }}" href="https://portal.wvu.edu">WVU Portal</a></li>
         </ul>
         <ul class="list-unstyled">
-          <li class="list-inline-item"><a class="{{ link_class }} h5" href="https://www.facebook.com/wvumountaineers"><i title="Facebook Icon" class="fab fa-facebook-square"></i><span class="visually-hidden">WVU on Facebook</span></a></li>
-          <li class="list-inline-item"><a class="{{ link_class }} h5" href="https://twitter.com/WestVirginiaU"><i title="Twitter Icon" class="fab fa-twitter-square"></i><span class="visually-hidden">WVU on Twitter</span></a></li>
-          <li class="list-inline-item"><a class="{{ link_class }} h5" href="https://www.youtube.com/user/westvirginiau"><i title="YouTube Icon" class="fab fa-youtube-square"></i><span class="visually-hidden">WVU on YouTube</span></a></li>
+          <li class="list-inline-item">
+            <a class="{{ link_class }} h5" href="https://www.facebook.com/wvumountaineers">
+              <span class="fab fa-facebook-square" aria-hidden="true"></span>
+              <span class="visually-hidden">WVU on Facebook</span>
+            </a>
+          </li>
+          <li class="list-inline-item">
+            <a class="{{ link_class }} h5" href="https://twitter.com/WestVirginiaU">
+              <span class="fab fa-twitter-square" aria-hidden="true"></span>
+              <span class="visually-hidden">WVU on Twitter</span>
+            </a>
+          </li>
+          <li class="list-inline-item">
+            <a class="{{ link_class }} h5" href="https://www.youtube.com/user/westvirginiau">
+              <span class="fab fa-youtube-square" aria-hidden="true"></span>
+              <span class="visually-hidden">WVU on YouTube</span>
+            </a>
+          </li>
         </ul>
       </div>
     </div>

--- a/views/components/wvu-page-collection-icons/_wvu-page-collection-icons--v1.html
+++ b/views/components/wvu-page-collection-icons/_wvu-page-collection-icons--v1.html
@@ -64,7 +64,7 @@
             {% if item.data.icon_code != blank %}
               <div class="mb-2 d-flex justify-items-center">
                 <div class="{{ iconClasses }} h1 rounded-circle p-4 d-flex mx-auto align-items-center justify-content-center {{ iconClasses }}">
-                  <i class="{{ item.data.icon_code }} position-absolute"></i>
+                  <span class="{{ item.data.icon_code }} position-absolute" aria-hidden="true"></span>
                 </div>
               </div>
             {% endif %}

--- a/views/components/wvu-program-listing/_wvu-program-listing--v1.html
+++ b/views/components/wvu-program-listing/_wvu-program-listing--v1.html
@@ -149,7 +149,7 @@
                         {% endif %}
                         {% for deliveryOption in programEntry.courseDeliveryOptions %}
                           {% if deliveryOption == 'Online' %}
-                            <div class="badge bg-primary"><span class="fa-solid fa-laptop"></span> Online</div>
+                            <div class="badge bg-primary"><span class="fa-solid fa-laptop" aria-hidden="true"></span> Online</div>
                           {% endif %}
                         {% endfor %}
 
@@ -163,7 +163,7 @@
                             <h3 class="border-bottom border-light h5 mt-3">Areas of Emphasis</h3>
                             <ul class="list-unstyled">
                               {% for area in programEntry.areasOfEmphasis %}
-                                <li><span class="fa-solid fa-angle-right text-wvu-gold"></span> {{ area.title }}</li>
+                                <li><span class="fa-solid fa-angle-right text-wvu-gold" aria-hidden="true"></span> {{ area.title }}</li>
                               {% endfor %}
                             </ul>
                           {% endif %}
@@ -178,63 +178,63 @@
                           {% if webAddress contains "https://online.wvu.edu/" or programEntry.degreeDesignation.abbreviation == 'BMDS' %}
                             <div class="btn-group-vertical w-100 shadow-sm">
                               <a class="btn btn-light text-left w-100 d-flex align-items-center" href="{{ webAddress }}">
-                                <span class="fa-solid fa-external-link-alt text-center" style="width: 2rem;"></span> View Program Page<span class="visually-hidden">: {{ programEntry.title }}</span>
+                                <span class="fa-solid fa-external-link-alt text-center" aria-hidden="true" style="width: 2rem;"></span> View Program Page<span class="visually-hidden">: {{ programEntry.title }}</span>
                               </a>
                             </div>
                           {% elsif webAddress contains "http://catalog.wvu.edu/" %}
                             <div class="btn-group-vertical w-100 shadow-sm">
                               <a class="btn btn-light text-left w-100 d-flex align-items-center" href="{{ webAddress }}">
-                                <span class="fa-solid fa-external-link-alt text-center" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>View in Course Catalog
+                                <span class="fa-solid fa-external-link-alt text-center" aria-hidden="true" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>View in Course Catalog
                               </a>
                             </div>
                           {% else %}
                             <div class="btn-group-vertical w-100 shadow-sm">
                               {% capture cardTitle %}{{ programEntry.title }}{% if programEntry.courseDeliveryOptions[0] == 'Online' %} (Online){% endif %} {{ programEntry.degreeDesignation.title }}{% endcapture %}
                               <a class="btn btn-light text-left w-100 d-flex align-items-center" href="{{ programEntry.webAddressAdmissions }}#wvu-main-content">
-                                <span class="fa-solid fa-file-alt text-center" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Overview
+                                <span class="fa-solid fa-file-alt text-center" aria-hidden="true" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Overview
                               </a>
                               <a class="btn btn-light text-left w-100 d-flex align-items-center" href="{{ programEntry.webAddressAdmissions }}#degree-plan">
-                                <span class="fa-solid fa-clipboard-list text-center" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Your Degree Plan
+                                <span class="fa-solid fa-clipboard-list text-center" aria-hidden="true" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Your Degree Plan
                               </a>
                               <!-- <a class="btn btn-light text-left w-100 d-flex align-items-center" href="#">
-                                <i class="fa-solid fa-sort text-center" style="width: 2rem;"></i> Rankings
+                                <span class="fa-solid fa-sort text-center" aria-hidden="true" style="width: 2rem;"></span> Rankings
                               </a> -->
                               <a class="btn btn-light text-left w-100 d-flex align-items-center" href="{{ programEntry.webAddressAdmissions }}#requirements">
-                                <span class="fa-solid fa-check-square text-center" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Admission Requirements
+                                <span class="fa-solid fa-check-square text-center" aria-hidden="true" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Admission Requirements
                               </a>
                               {% if programEntry.hepcLevelKey == 'bachelor' %}
                                 <a class="btn btn-light text-left w-100 d-flex align-items-center" href="{{ programEntry.webAddressAdmissions }}#tuition">
-                                  <span class="fa-solid fa-dollar-sign text-center" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Tuition and Aid
+                                  <span class="fa-solid fa-dollar-sign text-center" aria-hidden="true" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Tuition and Aid
                                 </a>
                               {% endif %}
                               {% comment %}
                               <a class="btn btn-light text-left w-100 d-flex align-items-center" href="{{ programEntry.webAddressAdmissions }}#related-programs">
-                                <span class="fa-solid fa-arrows-alt-h text-center" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Related Programs
+                                <span class="fa-solid fa-arrows-alt-h text-center" aria-hidden="true" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Related Programs
                               </a>
                               {% endcomment %}
                               {% if programEntry.hasCareers == 'true' %}
                                 <a class="btn btn-light text-left w-100 d-flex align-items-center" href="{{ programEntry.webAddressAdmissions }}#careers">
-                                  <span class="fa-solid fa-user-tie text-center" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Careers and Outcomes
+                                  <span class="fa-solid fa-user-tie text-center" aria-hidden="true" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Careers and Outcomes
                                 </a>
                               {% endif %}
                               {% if programEntry.hasFAQs == 'true' %}
                                 <a class="btn btn-light text-left w-100 d-flex align-items-center" href="{{ programEntry.webAddressAdmissions }}#faqs">
-                                  <span class="fa-solid fa-question-circle text-center" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Frequently Asked Questions
+                                  <span class="fa-solid fa-question-circle text-center" aria-hidden="true" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Frequently Asked Questions
                                 </a>
                               {% endif %}
                               {% if programEntry.hasProfiles == 'true' %}
                                 <a class="btn btn-light text-left w-100 d-flex align-items-center" href="{{ programEntry.webAddressAdmissions }}#community">
-                                  <span class="fa-solid fa-users text-center" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Meet Your Community
+                                  <span class="fa-solid fa-users text-center" aria-hidden="true" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Meet Your Community
                                 </a>
                               {% endif %}
                               {% if programEntry.hasPlaces == 'true' %}
                                 <a class="btn btn-light text-left w-100 d-flex align-items-center" href="{{ programEntry.webAddressAdmissions }}#places">
-                                  <span class="fa-solid fa-university text-center" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Places and Spaces
+                                  <span class="fa-solid fa-university text-center" aria-hidden="true" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Places and Spaces
                                 </a>
                               {% endif %}
                               {% if programEntry.degreeDesignation.abbreviation != 'BMDS' %}
                                 <a class="btn btn-light text-left w-100 d-flex align-items-center" href="{{ programEntry.webAddressAdmissions }}#learning">
-                                  <span class="fa-solid fa-walking text-center" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Learn By Doing
+                                  <span class="fa-solid fa-walking text-center" aria-hidden="true" style="width: 2rem;"></span> <span class="visually-hidden">{{ cardTitle }}: </span>Learn By Doing
                                 </a>
                               {% endif %}
                             </div>

--- a/views/includes/wvu-component-footer/_wvu-component-footer--v1.html
+++ b/views/includes/wvu-component-footer/_wvu-component-footer--v1.html
@@ -12,7 +12,7 @@
   {% assign ariaLabelRegionName = component.name | append: '-aria-label' %}
   {% assign customItemColorsRegion = component.name | append: '__item-colors' %}
 
-  <button class="editpanelbutton wvu-z-index-max text-white p-1 rounded-sm d-inline-block btn btn-sm btn-wvu-neutral--black wvu-grow-shadow wvu-z-index-content position-absolute {% if component.baseName == "breadcrumbs" %}mt-4 {% else %}mt-n4 {% endif %}ml-1 ms-1" data-bs-toggle="collapse" data-bs-target="#editpanel-{{ component.name }}" type="button" aria-expanded="false" aria-controls="editpanel-{{ component.name }}"><small class="d-block"><i class="far fa-edit"></i> Edit <span class="text-capitalize">{{ component.baseName | replace: '-', ' ' }}</span> {{ component.number }} Styles</small></button>
+  <button class="editpanelbutton wvu-z-index-max text-white p-1 rounded-sm d-inline-block btn btn-sm btn-wvu-neutral--black wvu-grow-shadow wvu-z-index-content position-absolute {% if component.baseName == "breadcrumbs" %}mt-4 {% else %}mt-n4 {% endif %}ml-1 ms-1" data-bs-toggle="collapse" data-bs-target="#editpanel-{{ component.name }}" type="button" aria-expanded="false" aria-controls="editpanel-{{ component.name }}"><small class="d-block"><span class="far fa-edit" aria-hidden="true"></span> Edit <span class="text-capitalize">{{ component.baseName | replace: '-', ' ' }}</span> {{ component.number }} Styles</small></button>
   <section class="editpanel px-2 px-md-5 pt-2 pb-3 mb-0 text-light bg-wvu-neutral--black position-relative collapse multi-collapse" id="editpanel-{{ component.name }}">
     <p class="mb-0">
       <!-- Region Name: {{component.region_names.classes}} -->


### PR DESCRIPTION
While this is no longer something that Siteimprove checks for, they used to recommend not using the `<i>` tag for icons. I tend to agree in this regard since the `<i>` tag is the [idomatic text element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i). `<span>` tags have no meaning and, for the changes outlined here, each icon is decorative. 

This PR also explicitly adds `aria-hidden="true"` to each icon. I know the FontAwesome JS does this anyway when transcoding these icons to SVG. Adding `aria-hidden` in these cases makes accessibility more explicit—as these components could be used without a FontAwesome kit at some point in the future. It also safeguards us when JS might fail on the client.