### PR TITLE
Hide icon link from assistive technology in page collection vertical icons component

### DIFF
--- a/views/components/wvu-page-collection-vertical-icons/_wvu-page-collection-vertical-icons--v1.html
+++ b/views/components/wvu-page-collection-vertical-icons/_wvu-page-collection-vertical-icons--v1.html
@@ -71,7 +71,7 @@
             <div class="row">
               <div class="col-lg-3">
                 {% if item.data.icon_code != blank %}
-                  <a title="{{ itemReadMoreButtonText }}: {{ item.name }}" href="{{ link_href }}">
+                  <a aria-hidden="true" tabindex="-1" href="{{ link_href }}">
                     <div class="mb-2 d-flex justify-items-center">
                       <div class="{{ iconClasses }} h1 rounded-circle p-4 d-flex mx-auto mx-lg-0 ms-lg-auto align-items-center justify-content-center">
                         <span class="{{ item.data.icon_code }} position-absolute"></span>


### PR DESCRIPTION
On the [Page Collection Vertical - Icons](https://dsws.sandbox.wvu.edu/components/collections/page-collection-vertical-icons) component, users can click the icon because it's a link.

For AT users, having the same link read to them 3x is redundant. This PR removes the link for AT users and removes it from the tab order.