### PR TITLE
Dont include twitterFetcher_min 2x.

### DIFF
--- a/views/layouts/default.html
+++ b/views/layouts/default.html
@@ -77,7 +77,7 @@
 
     {% render "components/wvu-footer" scope: 'site' %}
 
-    {% link_javascript name: "vendor/bootstrap/bootstrap.bundle.min, vendor/responsive-nav/responsive-nav, responsive-nav-dropdown--custom, vendor/twitter-fetcher/twitterFetcher_min" %}
+    {% link_javascript name: "vendor/bootstrap/bootstrap.bundle.min, vendor/responsive-nav/responsive-nav, responsive-nav-dropdown--custom" %}
 
     {{ content_for.page_js }}
 


### PR DESCRIPTION
This JS is included in the component partial _and_ in `default.html`. Obviously, it only needs to be included once. Better to include it only if a page uses the Twitter Feed component.

Here's a link to [where it's included in the component](https://github.com/wvuweb/wvu-design-system-v2/blob/master/views/components/wvu-twitter-widget/_wvu-twitter-widget--v1.html#L55).