### PR TITLE
Make Profile Hero with Quote use the `<blockquote>` HTML element.

### DIFF
--- a/views/components/wvu-profile-hero-w-quote/_wvu-profile-hero-w-quote--v1.html
+++ b/views/components/wvu-profile-hero-w-quote/_wvu-profile-hero-w-quote--v1.html
@@ -19,17 +19,17 @@
             {% comment %}<!-- This is just a label for the editable region that follows in order to make it clear to content editors what the region is for (in case they delete content and forget). -->{% endcomment %}
             {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Header</span>{% endif %}
             {% comment %}<!-- For the h1, apply an ID that will tell screanreaders to use this element as the label for the section. Also apply classes to the header. If supplied by user, use those. If not use default. -->{% endcomment %}
-            <h1 id="{{ component.name }}-label" class="wvu-quote {{ page.content[component.region_names.headerClasses] | default: component.defaultHeaderClasses }}">
+            <blockquote class="wvu-quote mx-0 {{ page.content[component.region_names.headerClasses] | default: component.defaultHeaderClasses }}">
               {% comment %}<!-- Use the editable region name for th header section of the hero, which you defined above. -->{% endcomment %}
               {% editable_region name: component.region_names.header, scope: component.scope, type: "simple", placeholder="We need a paradigm shift draft policy ppml proposal. Closing these latest prospects is like putting socks on an octopus prairie dogging. Goalposts closer to the metal fire up your browser. Killing it product management breakout fastworks for it's about managing expectations for those options are already baked in with this model ultimate measure of success." %}
-            </h1>
+            </blockquote>
             {% comment %}<!-- This is just a label for the editable region that follows in order to make it clear to content editors what the region is for (in case they delete content and forget). -->{% endcomment %}
             {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Main Content</span>{% endif %}
             {% comment %}<!-- Editable region for main content. -->{% endcomment %}
             {% editable_region_block name: component.region_names.main scope: component.scope %}
-              <h2 class="helvetica-neue-light mb-0 h5">Example Profile E</h2>
+              <h1 id="{{ component.name }}-label" class="helvetica-neue-light mb-0 h5">Example Profile E</h1>
               <p>
-                <small class="d-block ">Biology, Class of ’22</small>
+                <span class="d-block small">Biology, Class of ’22</span>
               </p>
             {% endeditable_region_block %}
 

--- a/views/components/wvu-profile-hero-w-quote/_wvu-profile-hero-w-quote--v1.html
+++ b/views/components/wvu-profile-hero-w-quote/_wvu-profile-hero-w-quote--v1.html
@@ -17,16 +17,17 @@
               </small>
             {% endif %}
             {% comment %}<!-- This is just a label for the editable region that follows in order to make it clear to content editors what the region is for (in case they delete content and forget). -->{% endcomment %}
-            {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Header</span>{% endif %}
-            {% comment %}<!-- For the h1, apply an ID that will tell screanreaders to use this element as the label for the section. Also apply classes to the header. If supplied by user, use those. If not use default. -->{% endcomment %}
+            {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Quote</span>{% endif %}
+            {% comment %}<!-- Apply classes to the header. If supplied by user, use those. If not use default. -->{% endcomment %}
             <blockquote class="wvu-quote mx-0 {{ page.content[component.region_names.headerClasses] | default: component.defaultHeaderClasses }}">
-              {% comment %}<!-- Use the editable region name for th header section of the hero, which you defined above. -->{% endcomment %}
-              {% editable_region name: component.region_names.header, scope: component.scope, type: "simple", placeholder="We need a paradigm shift draft policy ppml proposal. Closing these latest prospects is like putting socks on an octopus prairie dogging. Goalposts closer to the metal fire up your browser. Killing it product management breakout fastworks for it's about managing expectations for those options are already baked in with this model ultimate measure of success." %}
+              {% comment %}<!-- Use the editable region name for the header section of the hero, which you defined above. -->{% endcomment %}
+              <p>{% editable_region name: component.region_names.header, scope: component.scope, type: "simple", placeholder="We need a paradigm shift draft policy ppml proposal. Closing these latest prospects is like putting socks on an octopus prairie dogging. Goalposts closer to the metal fire up your browser. Killing it product management breakout fastworks for it's about managing expectations for those options are already baked in with this model ultimate measure of success." %}</p>
             </blockquote>
             {% comment %}<!-- This is just a label for the editable region that follows in order to make it clear to content editors what the region is for (in case they delete content and forget). -->{% endcomment %}
-            {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Main Content</span>{% endif %}
-            {% comment %}<!-- Editable region for main content. -->{% endcomment %}
+            {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Quote Author and Subhead</span>{% endif %}
+            {% comment %}<!-- Editable region for Quote Author and Subhead. -->{% endcomment %}
             {% editable_region_block name: component.region_names.main scope: component.scope %}
+              <!-- For the h1, apply an ID that will tell screanreaders to use this element as the label for the section. -->
               <h1 id="{{ component.name }}-label" class="helvetica-neue-light mb-0 h5">Example Profile E</h1>
               <p>
                 <span class="d-block small">Biology, Class of ’22</span>


### PR DESCRIPTION
Swaps out the h1 👉 blockquote.

Makes the h2 👉 h1.

If ya'll don't agree with me here, feel free to speak up. To me, it seems logical that the short item (a person's name) would be the h1, while the quote would use `blockquote`. 

[Profile Hero with Quote](https://dsws.sandbox.wvu.edu/components/profiles/profile-hero-w-quote) docs.