### PR TITLE
Update usage of 'build_image_url' Liquid filter to reflect recent changes

### DIFF
--- a/views/components/wvu-article-collection/_wvu-article-collection--v1.html
+++ b/views/components/wvu-article-collection/_wvu-article-collection--v1.html
@@ -67,7 +67,7 @@
           {% capture htag_id %}{{ item.slug }}-{{ component.name }}-{{ item.id }}{% endcapture %}
 
           <div class="{{ page.content[component.region_names.itemClasses] | default: itemClasses }}">
-            {% assign thumbnail_url = item.data.thumbnail_url | build_image_url: format: '1600x1200.jpg' %}
+            {% assign thumbnail_url = item.data.thumbnail_url | build_image_url: size: '1600x1200', format: 'jpg' %}
             {% if thumbnail_url != blank %}
               <div class="mb-2">
                 <a title="{{ itemReadMoreButtonText }}: {{ item.name }}" href="{{ link_href }}"><img class="card-img-top" src="{{ thumbnail_url }}" alt="{{ item.data.thumbnail_alt  }}"></a>

--- a/views/components/wvu-faculty-member-hero/_wvu-faculty-member-hero--v1.html
+++ b/views/components/wvu-faculty-member-hero/_wvu-faculty-member-hero--v1.html
@@ -25,10 +25,10 @@
           <div class="col-xl-10 me-xl-auto">
             <div class="mb-1">
               {% if page.data.thumbnail_url_sq != blank %}
-                {% assign thumbnailSrc = page.data.thumbnail_url_sq | build_image_url: format: '1600x1200.jpg' %}
+                {% assign thumbnailSrc = page.data.thumbnail_url_sq | build_image_url: size: '1600x1200', format: 'jpg' %}
                 <img class="card-img-top w-100" src="{{ thumbnailSrc }}/381x255.jpg" srcset="{{ thumbnailSrc }}/960x640.jpg, {{ thumbnailSrc }}/586x286.jpg, {{ thumbnailSrc }}/381x255.jpg, {{ thumbnailSrc }}/286x191.jpg, {{ thumbnailSrc }}/279x186.jpg, {{ thumbnailSrc }}/217x145.jpg" sizes="960px, (min-width: 768px) 586px" alt="{{ item.data.thumbnail_alt }}">
               {% elsif page.data.thumbnail_url != blank %}
-                {% assign thumbnailSrc = page.data.thumbnail_url | build_image_url: format: '1600x1200.jpg' %}
+                {% assign thumbnailSrc = page.data.thumbnail_url | build_image_url: size: '1600x1200', format: 'jpg' %}
                 <img class="card-img-top w-100" src="{{ thumbnailSrc }}/381x255.jpg" srcset="{{ thumbnailSrc }}/960x640.jpg, {{ thumbnailSrc }}/586x286.jpg, {{ thumbnailSrc }}/381x255.jpg, {{ thumbnailSrc }}/286x191.jpg, {{ thumbnailSrc }}/279x186.jpg, {{ thumbnailSrc }}/217x145.jpg" sizes="960px, (min-width: 768px) 586px" alt="{{ item.data.thumbnail_alt }}">
               {% else %}
                 {% if edit_mode %}

--- a/views/components/wvu-masthead/_wvu-masthead--v1.html
+++ b/views/components/wvu-masthead/_wvu-masthead--v1.html
@@ -10,7 +10,7 @@
           {% if site.data.has_co_brand == blank %}
             <a class="d-block position-relative my-3 text-decoration-none" href="/">
               <span class="visually-hidden">West Virginia University </span>
-              {% assign logoSrc = site.data.has_alternate_logo | build_image_url: format: '284x90' %}
+              {% assign logoSrc = site.data.has_alternate_logo | build_image_url: size: '284x90' %}
               <img class="my-n2" src="{{ logoSrc }}" alt="{{ site.name }}" />
             </a>
           {% else %}
@@ -22,7 +22,7 @@
               {% if site.data.has_co_brand == '1' %}
                 <span class="wvu-co-branding d-inline-block align-self-center mx-2 my-n2 p-2 border-start">
                   {% if site.data.has_alternate_logo != blank %}
-                    {% assign logoSrc = site.data.has_alternate_logo | build_image_url: format: '284x90' %}
+                    {% assign logoSrc = site.data.has_alternate_logo | build_image_url: size: '284x90' %}
                     <img src="{{ logoSrc }}" alt="{{ site.name }}" />
                   {% endif %}
                   {% if site.data.co_brand_subtitle != blank %}
@@ -41,7 +41,7 @@
             {% if site.data.has_co_brand != blank %}
               <span class="wvu-co-branding d-inline-block align-self-center mx-2 {% if site.data.co_brand_subtitle != blank %}my-n2 {% endif %}p-2 border-start">
                 {% if site.data.has_alternate_logo != blank %}
-                  {% assign logoSrc = site.data.has_alternate_logo | build_image_url: format: '284x90' %}
+                  {% assign logoSrc = site.data.has_alternate_logo | build_image_url:  size: '284x90' %}
                   <img src="{{ logoSrc }}" alt="Logo: {{ site.name }}" />
                 {% else %}
                   {{ site.data.has_co_brand }}

--- a/views/components/wvu-page-collection/_wvu-page-collection--v1.html
+++ b/views/components/wvu-page-collection/_wvu-page-collection--v1.html
@@ -63,7 +63,7 @@
           <div class="{{ page.content[component.region_names.itemClasses] | default: itemClasses }}">
             {% if item.data.thumbnail_url != blank %}
 
-              {% assign itemThumbnailSrc = item.data.thumbnail_url | build_image_url: format: '1600x1200' %}
+              {% assign itemThumbnailSrc = item.data.thumbnail_url | build_image_url: size: '1600x1200' %}
 
               <div class="mb-2 position-relative">
                 {% if item.data.badge_label != blank %}

--- a/views/components/wvu-profile/_wvu-profile--v1.html
+++ b/views/components/wvu-profile/_wvu-profile--v1.html
@@ -25,10 +25,10 @@
           <div class="col-xl-10 me-xl-auto">
             <div class="mb-1">
               {% if page.data.thumbnail_url_sq != blank %}
-                {% assign thumbnailSrc = page.data.thumbnail_url_sq | build_image_url: format: '960x640' %}
+                {% assign thumbnailSrc = page.data.thumbnail_url_sq | build_image_url: size: '960x640' %}
                 <img class="card-img-top w-100" src="{{ thumbnailSrc }}" alt="{{ item.data.thumbnail_alt }}">
               {% elsif page.data.thumbnail_url != blank %}
-                {% assign thumbnailSrc = page.data.thumbnail_url | build_image_url: format: '960x640' %}
+                {% assign thumbnailSrc = page.data.thumbnail_url | build_image_url: size: '960x640' %}
                 <img class="card-img-top w-100" src="{{ thumbnailSrc }}" alt="{{ item.data.thumbnail_alt }}">
               {% else %}
                 {% if edit_mode %}


### PR DESCRIPTION
I recently updated the `build_image_url` filter implementation in CleanSlate to accept distinct `size` and `format` arguments. I made these changes to the theme to reflect those updates and promote the 'correct' way to call `build_image_url` from now on.

`size` is a required argument
`format` is optional, with the default being the format of the original, uploaded image