### PR TITLE
Hide image link from assistive technology in blog article components

### DIFF
--- a/views/components/wvu-article-collection/_wvu-article-collection--v1.html
+++ b/views/components/wvu-article-collection/_wvu-article-collection--v1.html
@@ -62,7 +62,7 @@
               assign link_href = item.url
             endif
 
-            if item.data.link_text != blank
+            if itemReadMoreButtonText != 'none'
               assign hideImgLink = 'aria-hidden="true" tabindex="-1" '
             endif
           %}

--- a/views/components/wvu-article-collection/_wvu-article-collection--v1.html
+++ b/views/components/wvu-article-collection/_wvu-article-collection--v1.html
@@ -61,6 +61,10 @@
             else
               assign link_href = item.url
             endif
+
+            if item.data.link_text != blank
+              assign hideImgLink = 'aria-hidden="true" tabindex="-1" '
+            endif
           %}
 
           {% capture htag_id %}{{ item.slug }}-{{ component.name }}-{{ item.id }}{% endcapture %}
@@ -69,7 +73,9 @@
             {% assign itemThumbnailSrc = item.data.thumbnail_url | build_image_url: size: '960x640' %}
             {% if itemThumbnailSrc != blank %}
               <div class="mb-2">
-                <a title="{{ itemReadMoreButtonText }}: {{ item.name }}" href="{{ link_href }}"><img class="card-img-top" src="{{ itemThumbnailSrc }}" alt="{{ item.data.thumbnail_alt  }}"></a>
+                <a href="{{ link_href }}" title="{{ itemReadMoreButtonText }}: {{ item.name }}" {{ hideImgLink }}>
+                  <img class="card-img-top" src="{{ itemThumbnailSrc }}" alt="{{ item.data.thumbnail_alt  }}">
+                </a>
               </div>
             {% endif %}
 

--- a/views/components/wvu-article-index/_wvu-article-index--v1.html
+++ b/views/components/wvu-article-index/_wvu-article-index--v1.html
@@ -42,11 +42,15 @@
                   {% if article.data.thumbnail_url != blank %}
                     {% assign itemThumbnailSrc = article.data.thumbnail_url | build_image_url: size: '960x640' %}
                     <div class="col-md-3">
-                      <a href="{{ article.url }}"><img src="{{ itemThumbnailSrc }}" alt="{{ article.data.thumbnail_alt }}" /></a>
+                      <a href="{{ article.url }}" aria-hidden="true" tabindex="-1">
+                        <img src="{{ itemThumbnailSrc }}" alt="{{ article.data.thumbnail_alt }}" />
+                      </a>
                     </div>
                   {% elsif itemThumbSRC != blank %}
                     <div class="col-md-3">
-                      <a href="{{ article.url }}"><img src="{{ itemThumbSRC }}" alt="{{ itemAlt }}" /></a>
+                      <a href="{{ article.url }}" aria-hidden="true" tabindex="-1">
+                        <img src="{{ itemThumbSRC }}" alt="{{ itemAlt }}" />
+                      </a>
                     </div>
                   {% endif %}
                   <div class="col-md-9{% if article.data.thumbnail_url != blank or itemThumb != blank %} mt-3 mt-md-0{% else %} ms-md-auto{% endif %}">


### PR DESCRIPTION
The "Read More: {{ Article Title }}" already exists as a button below the article excerpt. So, no need to have it shown 2x or 3x to AT. 

You can see this change on Volutus for the [Article Collection](https://designsystemv2demo.volutus.wvu.edu/home/front-page-college-or-department?hh) and [Article Index](https://designsystemv2demo.volutus.wvu.edu/article-index).