### PR TITLE
Hide linked image in Page Collection components from assistive technology

### DIFF
--- a/views/components/wvu-page-collection-vertical/_wvu-page-collection-vertical--v1.html
+++ b/views/components/wvu-page-collection-vertical/_wvu-page-collection-vertical--v1.html
@@ -55,6 +55,10 @@
             else
               assign link_href = item.url
             endif
+
+            if itemReadMoreButtonText != 'none'
+              assign hideImgLink = 'aria-hidden="true" tabindex="-1" '
+            endif
           %}
 
           {% capture htag_id %}{{ item.slug }}-{{ component.name }}-{{ item.id }}{% endcapture %}
@@ -71,7 +75,7 @@
                         {{ item.data.badge_label }}
                       </div>
                     {% endif %}
-                    <a title="{{ itemReadMoreButtonText }}: {{ item.name }}" href="{{ link_href }}">
+                    <a {{ hideImgLink }} title="{{ itemReadMoreButtonText }}: {{ item.name }}" href="{{ link_href }}">
                       {% assign itemThumbnailSrc = item.data.thumbnail_url | build_image_url: size: '960x640' %}
                       <img class="card-img-top" src="{{ itemThumbnailSrc }}" alt="{{ item.data.thumbnail_alt }}">
                     </a>

--- a/views/components/wvu-page-collection/_wvu-page-collection--v1.html
+++ b/views/components/wvu-page-collection/_wvu-page-collection--v1.html
@@ -56,6 +56,10 @@
             else
               assign link_href = item.url
             endif
+
+            if itemReadMoreButtonText != 'none'
+              assign hideImgLink = 'aria-hidden="true" tabindex="-1" '
+            endif
           %}
 
           {% capture htag_id %}{{ item.slug }}-{{ component.name }}-{{ item.id }}{% endcapture %}
@@ -71,7 +75,7 @@
                     {{ item.data.badge_label }}
                   </div>
                 {% endif %}
-                <a title="{{ itemReadMoreButtonText }}: {{ item.name }}" href="{{ link_href }}">
+                <a {{ hideImgLink }} title="{{ itemReadMoreButtonText }}: {{ item.name }}" href="{{ link_href }}">
                   <img class="card-img-top" src="{{ itemThumbnailSrc }}" alt="{{ item.data.thumbnail_alt }}">
                 </a>
               </div>


### PR DESCRIPTION
[Page Collection](https://dsws.sandbox.wvu.edu/components/collections/page-collection) and [Page Collection Vertical](https://dsws.sandbox.wvu.edu/components/collections/page-collection-vertical) examples. This PR removes the image link from the tab order & AT; thus, decreasing repetition for screen reader and keyboard users.