### PR TITLE
Add `aria-hidden` to icons in directory and contact components.

### DIFF
--- a/views/components/wvu-contact-collection-vertical/_wvu-contact-collection-vertical--v1.html
+++ b/views/components/wvu-contact-collection-vertical/_wvu-contact-collection-vertical--v1.html
@@ -91,20 +91,20 @@
 
                   {% if item.content.wvu-profile-1__phone != blank %}
                     <p class="mb-0">
-                      <span class="fa-solid fa-phone"></span> <a href="tel:{{ item.content.wvu-profile-1__phone }}">{{ item.content.wvu-profile-1__phone }}</a>
+                      <span aria-hidden="true" class="fa-solid fa-phone"></span> <a href="tel:{{ item.content.wvu-profile-1__phone }}">{{ item.content.wvu-profile-1__phone }}</a>
                     </p>
                   {% endif %}
                   {% if item.content.wvu-profile-1__email != blank %}
                     <p class="mb-0">
-                      <span class="fa-solid fa-envelope"></span> <a href="mailto:{{ item.content.wvu-profile-1__email }}">{{ item.content.wvu-profile-1__email }}</a>
+                      <span aria-hidden="true" class="fa-solid fa-envelope"></span> <a href="mailto:{{ item.content.wvu-profile-1__email }}">{{ item.content.wvu-profile-1__email }}</a>
                     </p>
                   {% endif %}
                   {% if item.content.wvu-profile-1__office != blank %}
                     <p class="mb-0">
                       {% if item.content.wvu-profile-1__office-url != blank %}
-                        <span class="fa-solid fa-building"></span> <a href="mailto:{{ item.content.wvu-profile-1__office-url }}">{{ item.content.wvu-profile-1__office }}</a>
+                        <span aria-hidden="true" class="fa-solid fa-building"></span> <a href="mailto:{{ item.content.wvu-profile-1__office-url }}">{{ item.content.wvu-profile-1__office }}</a>
                       {% else %}
-                        <span class="fa-solid fa-building"> {{ item.content.wvu-profile-1__office }}</span>
+                        <span aria-hidden="true" class="fa-solid fa-building"></span> {{ item.content.wvu-profile-1__office }}
                       {% endif %}
                     </p>
                   {% endif %}

--- a/views/components/wvu-contact-collection/_wvu-contact-collection--v1.html
+++ b/views/components/wvu-contact-collection/_wvu-contact-collection--v1.html
@@ -91,20 +91,20 @@
 
               {% if item.content.wvu-profile-1__phone != blank %}
                 <p class="mb-0">
-                  <span class="fa-solid fa-phone"></span> <a href="tel:{{ item.content.wvu-profile-1__phone }}">{{ item.content.wvu-profile-1__phone }}</a>
+                  <span aria-hidden="true" class="fa-solid fa-phone"></span> <a href="tel:{{ item.content.wvu-profile-1__phone }}">{{ item.content.wvu-profile-1__phone }}</a>
                 </p>
               {% endif %}
               {% if item.content.wvu-profile-1__email != blank %}
                 <p class="mb-0">
-                  <span class="fa-solid fa-envelope"></span> <a href="mailto:{{ item.content.wvu-profile-1__email }}">{{ item.content.wvu-profile-1__email }}</a>
+                  <span aria-hidden="true" class="fa-solid fa-envelope"></span> <a href="mailto:{{ item.content.wvu-profile-1__email }}">{{ item.content.wvu-profile-1__email }}</a>
                 </p>
               {% endif %}
               {% if item.content.wvu-profile-1__office != blank %}
                 <p class="mb-0">
                   {% if item.content.wvu-profile-1__office-url != blank %}
-                    <span class="fa-solid fa-building"></span> <a href="mailto:{{ item.content.wvu-profile-1__office-url }}">{{ item.content.wvu-profile-1__office }}</a>
+                    <span aria-hidden="true" class="fa-solid fa-building"></span> <a href="mailto:{{ item.content.wvu-profile-1__office-url }}">{{ item.content.wvu-profile-1__office }}</a>
                   {% else %}
-                    <span class="fa-solid fa-building"></span> {{ item.content.wvu-profile-1__office }}
+                    <span aria-hidden="true" class="fa-solid fa-building"></span> {{ item.content.wvu-profile-1__office }}
                   {% endif %}
                 </p>
               {% endif %}

--- a/views/components/wvu-directory/_wvu-directory--v1.html
+++ b/views/components/wvu-directory/_wvu-directory--v1.html
@@ -22,7 +22,7 @@
       {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Header</span>{% endif %}
       {% comment %}<!-- For the h2, apply an ID that will tell screanreaders to use this element as the label for the section. Also apply classes to the header. If supplied by user, use those. If not use default. -->{% endcomment %}
       {% editable_region_block name: component.region_names.header scope: component.scope %}
-        <h2 id="{{ component.name }}-label" class="display-3 wvu-shout text-wvu-blue wvu-bar wvu-bar--bottom visually-hidden">Directory Headline</h2>
+        <h2 id="{{ component.name }}-label" class="display-3 wvu-shout text-wvu-blue wvu-slash wvu-slash--skinny visually-hidden">Directory Headline</h2>
       {% endeditable_region_block %}
     {%- endif %}
 
@@ -34,15 +34,16 @@
 
     <div class="table-responsive-md">
       <table class="table">
-        <tbody>
+        <caption class="caption-top visually-hidden">Directory</caption>
+        <tbody class="border-top-0">
           {% for item in items.all %}
             <tr class="border-bottom border-light">
-              <td class="py-2 w-25">
+              <th scope="row" class="py-2 w-25">
                 <div class="row">
                   <div class="col-4">
                     {% if item.data.thumbnail_url_sq != blank %}
                       {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '200x200' %}
-                      <img class="rounded-circle shadow d-inline-block" src="{{ itemThumbnailSrc }}" alt="{{ item.data.thumbnail_url_sq }}" />
+                      <img class="rounded-circle shadow d-inline-block" src="{{ itemThumbnailSrc }}" alt="{{ item.content['wvu-profile-1__name'] | default: item.name }} headshot" />
                     {% endif %}
                   </div>
                   <div class="col-8 align-self-center">
@@ -56,20 +57,20 @@
                     {%- endif %}
                   </div>
                 </div>
-              </td>
+              </th>
               <td class="align-middle">
                 {%- if item.content['wvu-profile-1__phone'] != blank %}
-                  <span class="fa-solid fa-phone"></span> <a href="tel:{{ item.content['wvu-profile-1__phone'] }}">{{ item.content['wvu-profile-1__phone'] }}</a>
+                  <span aria-hidden="true" class="fa-solid fa-phone"></span> <a href="tel:{{ item.content['wvu-profile-1__phone'] }}">{{ item.content['wvu-profile-1__phone'] }}</a>
                 {%- endif %}
               </td>
               <td class="align-middle">
                 {%- if item.content['wvu-profile-1__email'] != blank %}
-                  <span class="fa-solid fa-envelope"></span> <a href="mailto:{{ page.content['wvu-profile-1__email'] }}"> {{ item.content['wvu-profile-1__email'] }}</a>
+                  <span aria-hidden="true" class="fa-solid fa-envelope"></span> <a href="mailto:{{ page.content['wvu-profile-1__email'] }}"> {{ item.content['wvu-profile-1__email'] }}</a>
                 {%- endif %}
               </td>
               <td class="align-middle">
                 {%- if item.content['wvu-profile-1__office'] != blank %}
-                  <span class="fa-solid fa-building"></span> {%- if item.content['wvu-profile-1__office-url'] != blank %} <a href="{{ item.content['wvu-profile-1__office-url'] }}">{{ item.content['wvu-profile-1__office'] }}</a>{% else %} {{ item.content['wvu-profile-1__office'] }}{%- endif %}
+                  <span aria-hidden="true" class="fa-solid fa-building"></span> {%- if item.content['wvu-profile-1__office-url'] != blank %} <a href="{{ item.content['wvu-profile-1__office-url'] }}">{{ item.content['wvu-profile-1__office'] }}</a>{% else %} {{ item.content['wvu-profile-1__office'] }}{%- endif %}
                 {%- endif %}
               </td>
               {% if itemReadMoreButtonText != 'none' %}
@@ -79,7 +80,7 @@
                   {% capture link_text %}{{ itemReadMoreButtonText }}<span class="visually-hidden">: {{ item.name }}</span>{% endcapture %}
                 {% endif %}
                 <td class="align-middle">
-                  <span class="fa-solid fa-user-circle"></span> <a href="{{ link_href }}">{{ link_text }}</a>
+                  <span aria-hidden="true" class="fa-solid fa-user-circle"></span> <a href="{{ link_href }}">{{ link_text }}</a>
                 </td>
               {% endif %}
             </tr>

--- a/views/includes/wvu-contact-info/_wvu-contact-info--v1.html
+++ b/views/includes/wvu-contact-info/_wvu-contact-info--v1.html
@@ -10,7 +10,7 @@
 {% if edit_mode or page.content[regionNames.phone] != blank %}
   {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Phone</span>{% endif %}
   <span class="d-block position-relative ps-2">
-    <span class="fa-solid fa-phone ms-n2 position-absolute" style="top: 4px;"></span>
+    <span aria-hidden="true" class="fa-solid fa-phone ms-n2 position-absolute" style="top: 4px;"></span>
     <a class="d-block ms-1{% if edit_mode %} d-none{% endif %}" href="tel:{{ page.content[regionNames.phone] }}">{{ page.content[regionNames.phone] }}</a>
     {% if edit_mode %}
       {% editable_region name: regionNames.phone, scope: component.scope, type: "simple" %}
@@ -20,7 +20,7 @@
 {% if edit_mode or page.content[regionNames.email] != blank %}
   {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Email</span>{% endif %}
   <span class="d-block position-relative ps-2">
-    <span class="fa-solid fa-envelope ms-n2 position-absolute" style="top: 4px;"></span>
+    <span aria-hidden="true" class="fa-solid fa-envelope ms-n2 position-absolute" style="top: 4px;"></span>
     <a class="d-block ms-1" href="mailto:{{ page.content[regionNames.email] }}">{{ page.content[regionNames.email] }}</a>
     {% if edit_mode %}
       {% editable_region name: regionNames.email, scope: component.scope, type: "simple" %}
@@ -30,7 +30,7 @@
 {% if edit_mode or page.content[regionNames.office] != blank %}
   {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Office</span>{% endif %}
   <span class="d-block position-relative ps-2">
-    <span class="fa-solid fa-building ms-n2 position-absolute" style="top: 4px;"></span>
+    <span aria-hidden="true" class="fa-solid fa-building ms-n2 position-absolute" style="top: 4px;"></span>
       {% if page.content[regionNames.officeURL] != blank %}
         <a class="d-block ms-1{% if edit_mode %} d-none{% endif %}" href="{{ page.content[regionNames.officeURL] }}">{{ page.content[regionNames.office] }}</a>
       {% else %}
@@ -44,7 +44,7 @@
 {% if edit_mode %}
   {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Office URL</span>{% endif %}
   <span class="d-block position-relative ps-2">
-    <span class="fa-solid fa-link ms-n2 position-absolute" style="top: 4px;"></span>
+    <span aria-hidden="true" class="fa-solid fa-link ms-n2 position-absolute" style="top: 4px;"></span>
     {% if edit_mode %}
       {% editable_region name: regionNames.officeURL, scope: component.scope, type: "simple" %}
     {% endif %}
@@ -53,7 +53,7 @@
 {% if edit_mode or page.content[regionNames.website] != blank %}
   {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Website</span>{% endif %}
   <span class="d-block position-relative ps-2">
-    <span class="fa-solid fa-link ms-n2 position-absolute" style="top: 4px;"></span>
+    <span aria-hidden="true" class="fa-solid fa-link ms-n2 position-absolute" style="top: 4px;"></span>
     <a class="d-block ms-1{% if edit_mode %} d-none{% endif %}" href="{{ page.content[regionNames.website] }}">Website<span class="visually-hidden">: {{ page.name }}</span></a>
     {% if edit_mode %}
       {% editable_region name: regionNames.website, scope: component.scope, type: "simple" %}
@@ -68,5 +68,5 @@
 {% endif %}
 
 {% for file in files.all %}
-  <a href="{{ file.download_url }}" class="btn btn-sm btn-primary mt-1"><span class="fa-solid fa-file-pdf"></span> Download CV</a>
+  <a href="{{ file.download_url }}" class="btn btn-sm btn-primary mt-1"><span aria-hidden="true" class="fa-solid fa-file-pdf"></span> Download CV</a>
 {% endfor %}


### PR DESCRIPTION
Components affected:

  * [Contact collection](https://dsws.sandbox.wvu.edu/components/collections/contact-collection)
  * [Contact collection vertical](https://dsws.sandbox.wvu.edu/components/collections/contact-collection-vertical)
  * [Profile](https://dsws.sandbox.wvu.edu/components/page-layouts/profile)
  * [Directory](https://dsws.sandbox.wvu.edu/components/page-layouts/directory)

This PR also fixes the alt text of the profile photo in the directory component and makes the first `<td>` a `<th>` with `scope="row"`. 

Also, I changed some of the classes on the (visually hidden) `<h2>` in the directory because the `.wvu-bar::after` class caused a 1x1 pixel piece of the gold "bar" to be visible, even after adding `.visually-hidden`.