### PR TITLE
Make CleanSlate output WebP for most images

### DIFF
--- a/views/components/wvu-article-index/_wvu-article-index--v1.html
+++ b/views/components/wvu-article-index/_wvu-article-index--v1.html
@@ -35,7 +35,7 @@
                     {% for part in itemThumb %}
                       {% if part contains 'src=' %}
                         {% assign j = i | plus: 1 %}
-                        {% assign itemThumbSRC = itemThumb[j] | build_image_url: size: '960x640' %}
+                        {% assign itemThumbSRC = itemThumb[j] | build_image_url: size: '960x640', format: 'webp' %}
                       {% elsif part contains 'alt=' %}
                         {% assign k = i | plus: 1 %}
                         {% assign itemAlt = itemThumb[k] %}
@@ -45,7 +45,7 @@
                   {% endif %}
 
                   {% if article.data.thumbnail_url != blank %}
-                    {% assign itemThumbnailSrc = article.data.thumbnail_url | build_image_url: size: '960x640' %}
+                    {% assign itemThumbnailSrc = article.data.thumbnail_url | build_image_url: size: '960x640', format: 'webp' %}
                     <div class="col-md-3">
                       <a href="{{ article.url }}" aria-hidden="true" tabindex="-1">
                         <img src="{{ itemThumbnailSrc }}" alt="{{ article.data.thumbnail_alt }}" />

--- a/views/components/wvu-contact-collection-vertical/_wvu-contact-collection-vertical--v1.html
+++ b/views/components/wvu-contact-collection-vertical/_wvu-contact-collection-vertical--v1.html
@@ -64,7 +64,7 @@
               <div class="col-lg-3">
                 <div class="mb-2 position-relative">
                   {% if item.data.thumbnail_url_sq != blank %}
-                    {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '960x640' %}
+                    {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '960x640', format: 'webp' %}
                     <img class="rounded-circle shadow mb-2" src="{{ itemThumbnailSrc }}" alt="{{ item.data.thumbnail_alt  }}">
                   {% endif %}
                 </div>

--- a/views/components/wvu-contact-collection/_wvu-contact-collection--v1.html
+++ b/views/components/wvu-contact-collection/_wvu-contact-collection--v1.html
@@ -64,7 +64,7 @@
               <div class="row mb-1">
                 <div class="col-6 mx-auto col-sm-4 col-md-6">
                   {% if item.data.thumbnail_url_sq != blank %}
-                    {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '960x640' %}
+                    {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '960x640', format: 'webp' %}
                     <img class="rounded-circle shadow mb-2" src="{{ itemThumbnailSrc }}" alt="{{ item.data.thumbnail_alt  }}">
                   {% endif %}
                 </div>

--- a/views/components/wvu-directory/_wvu-directory--v1.html
+++ b/views/components/wvu-directory/_wvu-directory--v1.html
@@ -42,7 +42,7 @@
                 <div class="row">
                   <div class="col-4">
                     {% if item.data.thumbnail_url_sq != blank %}
-                      {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '200x200' %}
+                      {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '200x200', format: 'webp' %}
                       <img class="rounded-circle shadow d-inline-block" src="{{ itemThumbnailSrc }}" alt="{{ item.content['wvu-profile-1__name'] | default: item.name }} headshot" />
                     {% endif %}
                   </div>

--- a/views/components/wvu-faculty-member-hero/_wvu-faculty-member-hero--v1.html
+++ b/views/components/wvu-faculty-member-hero/_wvu-faculty-member-hero--v1.html
@@ -25,10 +25,10 @@
           <div class="col-xl-10 me-xl-auto">
             <div class="mb-1">
               {% if page.data.thumbnail_url_sq != blank %}
-                {% assign thumbnailSrc = page.data.thumbnail_url_sq | build_image_url: size: '640x640' %}
+                {% assign thumbnailSrc = page.data.thumbnail_url_sq | build_image_url: size: '640x640', format: 'webp' %}
                 <img class="card-img-top w-100" src="{{ thumbnailSrc }}" alt="{{ item.data.thumbnail_alt }}">
               {% elsif page.data.thumbnail_url != blank %}
-                {% assign thumbnailSrc = page.data.thumbnail_url | build_image_url: size: '960x640' %}
+                {% assign thumbnailSrc = page.data.thumbnail_url | build_image_url: size: '960x640', format: 'webp' %}
                 <img class="card-img-top w-100" src="{{ thumbnailSrc }}" alt="{{ item.data.thumbnail_alt }}">
               {% else %}
                 {% if edit_mode %}

--- a/views/components/wvu-masthead/_wvu-masthead--v1.html
+++ b/views/components/wvu-masthead/_wvu-masthead--v1.html
@@ -41,7 +41,7 @@
             {% if site.data.has_co_brand != blank %}
               <span class="wvu-co-branding d-inline-block align-self-center mx-2 {% if site.data.co_brand_subtitle != blank %}my-n2 {% endif %}p-2 border-start">
                 {% if site.data.has_alternate_logo != blank %}
-                  {% assign logoSrc = site.data.has_alternate_logo | build_image_url:  size: '284x90' %}
+                  {% assign logoSrc = site.data.has_alternate_logo | build_image_url: size: '284x90' %}
                   <img src="{{ logoSrc }}" alt="Logo: {{ site.name }}" />
                 {% else %}
                   {{ site.data.has_co_brand }}

--- a/views/components/wvu-people-collection-vertical/_wvu-people-collection-vertical--v1.html
+++ b/views/components/wvu-people-collection-vertical/_wvu-people-collection-vertical--v1.html
@@ -67,7 +67,7 @@
                 <div class="col-md-4">
                   <div class="row mb-1">
                     <div class="col-6 mx-auto col-sm-4 col-md-12 col-lg-8 col-xl-8 mx-lg-0 ms-lg-auto">
-                      {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '640x640' %}
+                      {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '640x640', format: 'webp' %}
                       <img class="rounded-circle shadow mb-2" src="{{ itemThumbnailSrc }}" alt="{{ item.data.thumbnail_alt  }}">
                     </div>
                   </div>

--- a/views/components/wvu-people-collection/_wvu-people-collection--v1.html
+++ b/views/components/wvu-people-collection/_wvu-people-collection--v1.html
@@ -64,7 +64,7 @@
               <div class="row mb-1">
                 <div class="col-6 mx-auto col-sm-4 col-md-6">
                   {% if item.data.thumbnail_url_sq != blank %}
-                    {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '640x640' %}
+                    {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '640x640', format: 'webp' %}
                     <img class="rounded-circle shadow mb-2" src="{{ itemThumbnailSrc }}" alt="{{ item.data.thumbnail_alt  }}">
                   {% endif %}
                 </div>

--- a/views/components/wvu-profile-teaser/_wvu-profile-teaser--v1.html
+++ b/views/components/wvu-profile-teaser/_wvu-profile-teaser--v1.html
@@ -53,7 +53,7 @@
           <div class="row">
             <div class="col-6 mr-auto col-md-12 col-lg-10 col-xl-8 me-lg-0 ms-lg-auto">
               {% if item.data.thumbnail_url_sq != blank %}
-                {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '640x640' %}
+                {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '640x640', format: 'webp' %}
                 <img class="rounded-circle shadow text-center" src="{{ itemThumbnailSrc }}" alt="{{ item.data.thumbnail_alt  }}">
               {% elsif item.data.thumbnail_url != blank %}
                 {% assign itemThumbnailSrc = item.data.thumbnail_url | build_image_url: size: '960x640', format: 'webp' %}

--- a/views/components/wvu-profile/_wvu-profile--v1.html
+++ b/views/components/wvu-profile/_wvu-profile--v1.html
@@ -25,10 +25,10 @@
           <div class="col-xl-10 me-xl-auto">
             <div class="mb-1">
               {% if page.data.thumbnail_url_sq != blank %}
-                {% assign thumbnailSrc = page.data.thumbnail_url_sq | build_image_url: size: '960x640' %}
+                {% assign thumbnailSrc = page.data.thumbnail_url_sq | build_image_url: size: '960x640', format: 'webp' %}
                 <img class="card-img-top w-100" src="{{ thumbnailSrc }}" alt="{{ item.data.thumbnail_alt }}">
               {% elsif page.data.thumbnail_url != blank %}
-                {% assign thumbnailSrc = page.data.thumbnail_url | build_image_url: size: '960x640' %}
+                {% assign thumbnailSrc = page.data.thumbnail_url | build_image_url: size: '960x640', format: 'webp' %}
                 <img class="card-img-top w-100" src="{{ thumbnailSrc }}" alt="{{ item.data.thumbnail_alt }}">
               {% else %}
                 {% if edit_mode %}

--- a/views/components/wvu-profiles-vertical/_wvu-profiles-vertical--v1.html
+++ b/views/components/wvu-profiles-vertical/_wvu-profiles-vertical--v1.html
@@ -42,7 +42,7 @@
           <div class="row mb-5">
             <div class="col-md-3 mr-ml-auto mb-1 text-center">
               {% if profile.data.thumbnail_url_sq != blank %}
-                {% assign itemThumbnailSrc = profile.data.thumbnail_url_sq | build_image_url: size: '640x640' %}
+                {% assign itemThumbnailSrc = profile.data.thumbnail_url_sq | build_image_url: size: '640x640', format: 'webp' %}
                 <img class="rounded-circle shadow text-center" src="{{ itemThumbnailSrc }}" alt="{{ profile.data.thumbnail_alt }}">
               {% endif %}
             </div>

--- a/views/components/wvu-testimonials/_wvu-testimonials--v1.html
+++ b/views/components/wvu-testimonials/_wvu-testimonials--v1.html
@@ -73,7 +73,7 @@
                 <div class="{% if itemCount == 1 %}col-5 mx-auto{% else %}col-3{% endif %}">
                   {% if item.data.thumbnail_url_sq != blank %}
                     <div class="mb-2">
-                      {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '640x640' %}
+                      {% assign itemThumbnailSrc = item.data.thumbnail_url_sq | build_image_url: size: '640x640', format: 'webp' %}
                       <img class="rounded-circle shadow text-center w-100" src="{{ itemThumbnailSrc }}" alt="{{ item.data.thumbnail_alt  }}">
                     </div>
                   {% endif %}


### PR DESCRIPTION
`*` Except for the Masthead component. That's one case where someone might (correctly) use an SVG.

Many components are [already using WebP](https://github.com/wvuweb/wvu-design-system-v2/commit/93cefdc2f9ac714f51fcd049995b670baf2715e9). This PR just makes every component that uses images use WebP. WebP also supports transparency and is widely supported across browsers; thus, making it a safe bet to move from JPG/PNG.

Some [background](https://web.dev/uses-webp-images/) on why this is beneficial. 