### PR TITLE
Add editable regions for fax numbers in contact info component.

### DIFF
--- a/views/components/wvu-contact-info/_wvu-contact-info--v2.html
+++ b/views/components/wvu-contact-info/_wvu-contact-info--v2.html
@@ -1,6 +1,7 @@
 {%- liquid
   assign addressEditableRegionName = component.baseName | prepend: 'wvu-' | append: '-' | append: component.number | append: '__address'
   assign phoneEditableRegionName = component.baseName | prepend: 'wvu-' | append: '-' | append: component.number | append: '__phone'
+  assign faxEditableRegionName = component.baseName | prepend: 'wvu-' | append: '-' | append: component.number | append: '__fax'
   assign emailEditableRegionName = component.baseName | prepend: 'wvu-' | append: '-' | append: component.number | append: '__email'
   assign individualEditableRegionName = component.baseName | prepend: 'wvu-' | append: '-' | append: component.number | append: '__individual'
   assign formEditableRegionName = component.baseName | prepend: 'wvu-' | append: '-' | append: '__form'
@@ -57,12 +58,29 @@
             </div>
           </div>
         {% endif %}
+        {% if edit_mode or page.content[faxEditableRegionName] != blank %}
+          <div class="d-flex mb-2">
+            <div class="h3"><span class="fa-solid fa-fax" aria-hidden="true"></span></div>
+            <div class="ms-2">
+              {% comment %}<!-- This is just a label for the editable region that follows in order to make it clear to content editors what the region is for (in case they delete content and forget). -->{% endcomment %}
+              {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Fax</span>{% endif %}
+              {% editable_region_block name: faxEditableRegionName scope: component.scope %}
+                <h2 class="h5 iowan-old-style-black">
+                  By Fax
+                </h2>
+                <address>
+                  (304) 293-5678
+                </address>
+              {% endeditable_region_block %}
+            </div>
+          </div>
+        {% endif %}
         {% if edit_mode or page.content[emailEditableRegionName] != blank %}
           <div class="d-flex mb-2">
             <div class="h3"><span class="fa-solid fa-envelope" aria-hidden="true"></span></div>
             <div class="ms-2">
               {% comment %}<!-- This is just a label for the editable region that follows in order to make it clear to content editors what the region is for (in case they delete content and forget). -->{% endcomment %}
-              {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Phone</span>{% endif %}
+              {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Email</span>{% endif %}
               {% editable_region_block name: emailEditableRegionName scope: component.scope %}
                 <h2 class="h5 iowan-old-style-black">
                   By Email
@@ -80,7 +98,7 @@
             <div class="h3"><span class="fa-solid fa-user-group" aria-hidden="true"></span></div>
             <div class="ms-2">
               {% comment %}<!-- This is just a label for the editable region that follows in order to make it clear to content editors what the region is for (in case they delete content and forget). -->{% endcomment %}
-              {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Phone</span>{% endif %}
+              {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Contact an individual</span>{% endif %}
               {% editable_region_block name: individualEditableRegionName scope: component.scope %}
                 <h2 class="h5 iowan-old-style-black">
                   Contact an Individual

--- a/views/components/wvu-faculty-member-hero/_wvu-faculty-member-hero--v1.html
+++ b/views/components/wvu-faculty-member-hero/_wvu-faculty-member-hero--v1.html
@@ -8,6 +8,7 @@
     "organization": "wvu-{{ component.name }}__organization",
     "subhead": "wvu-{{ component.name }}__subhead",
     "phone": "wvu-{{ component.name }}__phone",
+    "fax": "wvu-{{ component.name }}__fax",
     "email": "wvu-{{ component.name }}__email",
     "office": "wvu-{{ component.name }}__office",
     "officeURL": "wvu-{{ component.name }}__office-url",

--- a/views/components/wvu-profile/_wvu-profile--v1.html
+++ b/views/components/wvu-profile/_wvu-profile--v1.html
@@ -8,6 +8,7 @@
     "organization": "wvu-{{ component.name }}__organization",
     "subhead": "wvu-{{ component.name }}__subhead",
     "phone": "wvu-{{ component.name }}__phone",
+    "fax": "wvu-{{ component.name }}__fax",
     "email": "wvu-{{ component.name }}__email",
     "office": "wvu-{{ component.name }}__office",
     "officeURL": "wvu-{{ component.name }}__office-url",

--- a/views/includes/wvu-contact-info/_wvu-contact-info--v1.html
+++ b/views/includes/wvu-contact-info/_wvu-contact-info--v1.html
@@ -17,6 +17,16 @@
     {% endif %}
   </span>
 {% endif %}
+{% if edit_mode or page.content[regionNames.fax] != blank %}
+  {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Fax</span>{% endif %}
+  <span class="d-block position-relative ps-2">
+    <span aria-hidden="true" class="fa-solid fa-fax ms-n2 position-absolute" style="top: 4px;"></span>
+    <a class="d-block ms-1{% if edit_mode %} d-none{% endif %}" href="tel:{{ page.content[regionNames.fax] }}">{{ page.content[regionNames.fax] }}</a>
+    {% if edit_mode %}
+      {% editable_region name: regionNames.fax, scope: component.scope, type: "simple" %}
+    {% endif %}
+  </span>
+{% endif %}
 {% if edit_mode or page.content[regionNames.email] != blank %}
   {% if edit_mode %}<span class="d-inline-block badge bg-primary mb-1">Email</span>{% endif %}
   <span class="d-block position-relative ps-2">


### PR DESCRIPTION
Yes, in 2023, people still use faxes. My current client would like this added to the [contact info component](https://designsystem.wvu.edu/components/page-layouts/contact-info).

You can check out these changes in Volutus: [contact info in edit mode](https://cleanslate.volutus.wvu.edu/sites/1545/pages/140864/editor) and a [profile template](https://cleanslate.volutus.wvu.edu/sites/1545/pages/141421/editor).

If you want to preview them in staging (aka not edit mode), it looks like Nathan might have to do something on the back end.

After merging this, maybe switch the branch back to `master` in [Volutus Themes](https://cleanslate.volutus.wvu.edu/themes?utf8=%E2%9C%93&name=University+Relations%3A+WVU+Design+System+Version+2.0&order=sync_dt&sort=desc).