### PR TITLE
Fix blob em span

### DIFF
--- a/views/components/wvu-blob-a/_wvu-blob-a--v2.html
+++ b/views/components/wvu-blob-a/_wvu-blob-a--v2.html
@@ -56,7 +56,10 @@
                   <blockquote class="h3 mx-0 helvetica-neue-light">
                     <p>“{%- editable_region name: quoteRegionName, scope: component.scope, placeholder: "The biggest gifts the donors have given to us are encouragement and hope.", type: "simple" -%}”</p>
                   </blockquote>
-                  <p class="iowan-old-style-italic d-block mt-2 mb-0">— {% editable_region name: authorRegionName, scope: component.scope, placeholder: "Mannhu Iglesias, Class of 2018", type: "simple" %}</p>
+                  <p class="d-block mt-2 mb-0">
+                    <span class="iowan-old-style-italic">— {% editable_region name: authorRegionName, scope: component.scope, placeholder: "Mannhu Iglesias, Class of 2018", type: "simple" %}
+                    </span>
+                  </p>
                 </div>
               </div>
             </div>

--- a/views/components/wvu-testimonials-fancy/_wvu-testimonials-fancy--v2.html
+++ b/views/components/wvu-testimonials-fancy/_wvu-testimonials-fancy--v2.html
@@ -99,8 +99,10 @@
                   </div>
                   <div class="col-xl-6 me-md-auto">
                     <div class="bg-white p-3 p-xl-2 mt-xl-5 text-center wvu-z-index-content">
-                      <blockquote class="iowan-old-style-black-italic h6 mb-0 mx-0">
-                        <p class="mb-0">“{{ item.content.wvu-profile-1__quote }}”</p>
+                      <blockquote class="h6 mb-0 mx-0">
+                        <p class="mb-0">
+                          <span class="iowan-old-style-black-italic">“{{ item.content.wvu-profile-1__quote }}”</span>
+                        </p>
                       </blockquote>
                     </div>
                   </div>

--- a/views/components/wvu-testimonials-fancy/_wvu-testimonials-fancy--v2.html
+++ b/views/components/wvu-testimonials-fancy/_wvu-testimonials-fancy--v2.html
@@ -101,7 +101,7 @@
                     <div class="bg-white p-3 p-xl-2 mt-xl-5 text-center wvu-z-index-content">
                       <blockquote class="h6 mb-0 mx-0">
                         <p class="mb-0">
-                          <span class="iowan-old-style-black-italic">“{{ item.content.wvu-profile-1__quote }}”</span>
+                          <span class="d-block iowan-old-style-black-italic">“{{ item.content.wvu-profile-1__quote }}”</span>
                         </p>
                       </blockquote>
                     </div>


### PR DESCRIPTION
This fixes the 'overuse of italics' accessibility warning, using the fix outlined here:

- https://codepen.io/adamjohnson/full/ExGWxZy

Examples of the warning on DS site:

- https://designsystem.wvu.edu/components/data-presentations/blob-a (Sarah Iglesias, Class of 2018 text)
- https://designsystem.wvu.edu/components/profiles/testimonials-fancy (text in white boxes)


I don't have access to staging to test but don't foresee any issues with this change.